### PR TITLE
Specified :require => 'drip' for Gemfile inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Ruby toolkit for the [Drip](https://www.getdrip.com/) API.
 
 Add this line to your application's Gemfile:
 
-    gem 'drip-ruby'
+    gem 'drip-ruby', :require => 'drip' 
 
 And then execute:
 


### PR DESCRIPTION
The previous way of including the gem into `Gemfile` didn't work, because the correct file to `require` is `lib/drip.rb` (and not `lib/drip-ruby.rb`)
