### PR TITLE
Use JSON module in standard Ruby library

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A Ruby toolkit for the [Drip](https://www.getdrip.com/) API.
 [![Build Status](https://travis-ci.org/DripEmail/drip-ruby.svg?branch=master)](https://travis-ci.org/DripEmail/drip-ruby)
 [![Code Climate](https://codeclimate.com/github/DripEmail/drip-ruby/badges/gpa.svg)](https://codeclimate.com/github/DripEmail/drip-ruby)
 
+
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/drip-ruby.gemspec
+++ b/drip-ruby.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 1.9.3'
+
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "shoulda-context", "~> 1.0"
@@ -26,5 +28,4 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday_middleware", "~> 0.9"
-  spec.add_runtime_dependency "json", "~> 1.8"
 end


### PR DESCRIPTION
The gem wasn't working with Ruby 2.4 because of the dependency on the json gem v1.8, which appears to be broken in 2.4. Dropped it in favor of the JSON module in the standard Ruby library, which in turn requires Ruby 1.9.3 or greater.    