### PR TITLE
Match token/key wording in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 ## Authentication
 
-For private integrations, you may use your personal API key (found
+For private integrations, you may use your personal API Token (found
 [here](https://www.getdrip.com/user/edit)) via the `api_key` setting:
 
 ```ruby


### PR DESCRIPTION
The web UI displays an `API Token` value for a user’s profile, but this documentation specifies an `API key`.

The inconsistent use of `key` and `token` is confusing (perhaps the UI should call it `API Key`?), but this change at least describes the linked information more accurately.