### PR TITLE
add gem version batch to README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Ruby toolkit for the [Drip](https://www.getdrip.com/) API.
 
 [![Build Status](https://travis-ci.org/DripEmail/drip-ruby.svg?branch=master)](https://travis-ci.org/DripEmail/drip-ruby)
 [![Code Climate](https://codeclimate.com/github/DripEmail/drip-ruby/badges/gpa.svg)](https://codeclimate.com/github/DripEmail/drip-ruby)
-
+[![Gem Version](https://badge.fury.io/rb/drip-ruby.svg)](https://badge.fury.io/rb/drip-ruby)
 
 
 ## Installation


### PR DESCRIPTION
Thanks for merging https://github.com/DripEmail/drip-ruby/pull/28. This is just a shortcut to find the latest gem version faster.