### PR TITLE
Add options for http timeout protection

### DIFF
--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -18,12 +18,14 @@ module Drip
     include Campaigns
     include Purchases
 
-    attr_accessor :access_token, :api_key, :account_id
+    attr_accessor :access_token, :api_key, :account_id, :http_open_timeout, :http_timeout
 
     def initialize(options = {})
       @account_id = options[:account_id]
       @access_token = options[:access_token]
       @api_key = options[:api_key]
+      @http_open_timeout = options[:http_open_timeout]
+      @http_timeout = options[:http_timeout]
       yield(self) if block_given?
     end
 
@@ -82,6 +84,9 @@ module Drip
         else
           f.basic_auth api_key, ""
         end
+
+        f.options.open_timeout = @http_open_timeout
+        f.options.timeout = @http_timeout
 
         f.response :json, :content_type => /\bjson$/
         f.adapter :net_http

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -31,12 +31,16 @@ class Drip::ClientTest < Drip::TestCase
       client = Drip::Client.new(
         account_id: "1234567",
         api_key: "aaaa",
-        access_token: "bbbb"
+        access_token: "bbbb",
+        http_open_timeout: 20,
+        http_timeout: 25
       )
 
       assert_equal "1234567", client.account_id
       assert_equal "aaaa", client.api_key
       assert_equal "bbbb", client.access_token
+      assert_equal 20, client.http_open_timeout
+      assert_equal 25, client.http_timeout
     end
   end
 


### PR DESCRIPTION
This pull request adds timeout protection to the drip-ruby gem. The current library will essentially lock up upon making a request if a network or server issue prevents a timely response from the API.