### PR TITLE
Remove Faraday

### DIFF
--- a/drip-ruby.gemspec
+++ b/drip-ruby.gemspec
@@ -26,7 +26,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha", "~> 1.1"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "webmock", "~> 3.4"
-
-  spec.add_runtime_dependency "faraday", "~> 0.13"
-  spec.add_runtime_dependency "faraday_middleware", "~> 0.12"
 end

--- a/drip-ruby.gemspec
+++ b/drip-ruby.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shoulda-context", "~> 1.0"
   spec.add_development_dependency "mocha", "~> 1.1"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "webmock", "~> 3.4"
 
   spec.add_runtime_dependency "faraday", "~> 0.13"
   spec.add_runtime_dependency "faraday_middleware", "~> 0.12"

--- a/test/drip/client/accounts_test.rb
+++ b/test/drip/client/accounts_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::AccountsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#accounts" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "accounts" do
-        [@response_status, {}, @response_body]
-      end
+    stub_request(:get, "https://api.getdrip.com/v2/accounts").
+      to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -31,12 +23,11 @@ class Drip::Client::AccountsTest < Drip::TestCase
   context "#account" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 9999999
 
-      @stubs.get "accounts/#{@id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/accounts/#{@id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/broadcasts_test.rb
+++ b/test/drip/client/broadcasts_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::BroadcastsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#broadcasts" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/broadcasts" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/broadcasts").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the correct request" do
@@ -31,12 +23,11 @@ class Drip::Client::BroadcastsTest < Drip::TestCase
   context "#broadcast" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 99999
 
-      @stubs.get "12345/broadcasts/#{@id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/broadcasts/#{@id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the correct request" do

--- a/test/drip/client/campaign_subscriptions_test.rb
+++ b/test/drip/client/campaign_subscriptions_test.rb
@@ -2,25 +2,17 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::CampaignSubscriptionsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#campaign_subscriptions" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @subscriber_id = "abc123"
 
-      @stubs.get "12345/subscribers/#{@subscriber_id}/campaign_subscriptions" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/subscribers/#{@subscriber_id}/campaign_subscriptions").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/campaigns_test.rb
+++ b/test/drip/client/campaigns_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::CampaignsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#campaigns" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/campaigns" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/campaigns").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -31,12 +23,11 @@ class Drip::Client::CampaignsTest < Drip::TestCase
   context "#campaign" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 9999999
 
-      @stubs.get "12345/campaigns/#{@id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/campaigns/#{@id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -48,12 +39,11 @@ class Drip::Client::CampaignsTest < Drip::TestCase
   context "#activate_campaign" do
     setup do
       @response_status = 204
-      @response_body = stub
+      @response_body = nil
       @id = 9999999
 
-      @stubs.post "12345/campaigns/#{@id}/activate" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/campaigns/#{@id}/activate").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -65,12 +55,11 @@ class Drip::Client::CampaignsTest < Drip::TestCase
   context "#pause_campaign" do
     setup do
       @response_status = 204
-      @response_body = stub
+      @response_body = nil
       @id = 9999999
 
-      @stubs.post "12345/campaigns/#{@id}/pause" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/campaigns/#{@id}/pause").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -82,12 +71,11 @@ class Drip::Client::CampaignsTest < Drip::TestCase
   context "#campaign_subscribers" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 9999999
 
-      @stubs.get "12345/campaigns/#{@id}/subscribers" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/campaigns/#{@id}/subscribers").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/conversions_test.rb
+++ b/test/drip/client/conversions_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::ConversionsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#conversions" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/goals" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/goals").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -31,12 +23,11 @@ class Drip::Client::ConversionsTest < Drip::TestCase
   context "#conversion" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 9999999
 
-      @stubs.get "12345/goals/#{@id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/goals/#{@id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/custom_fields_test.rb
+++ b/test/drip/client/custom_fields_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::CustomFieldsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#custom_fields" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/custom_field_identifiers" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/custom_field_identifiers").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/events_test.rb
+++ b/test/drip/client/events_test.rb
@@ -2,14 +2,7 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::EventsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#track_event" do
@@ -30,11 +23,10 @@ class Drip::Client::EventsTest < Drip::TestCase
         }.to_json
 
         @response_status = 201
-        @response_body = stub
+        @response_body = "stub"
 
-        @stubs.post "12345/events", @payload do
-          [@response_status, {}, @response_body]
-        end
+        stub_request(:post, "https://api.getdrip.com/v2/12345/events").
+          to_return(status: @response_status, body: @response_body, headers: {})
       end
 
       should "send the right request" do
@@ -58,11 +50,10 @@ class Drip::Client::EventsTest < Drip::TestCase
         }.to_json
 
         @response_status = 201
-        @response_body = stub
+        @response_body = "stub"
 
-        @stubs.post "12345/events", @payload do
-          [@response_status, {}, @response_body]
-        end
+        stub_request(:post, "https://api.getdrip.com/v2/12345/events").
+          to_return(status: @response_status, body: @response_body, headers: {})
       end
 
       should "send the right request" do
@@ -87,11 +78,10 @@ class Drip::Client::EventsTest < Drip::TestCase
 
       @payload = { "batches" => [{ "events" => @events }] }.to_json
       @response_status = 201
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/events/batches", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/events/batches").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -103,11 +93,10 @@ class Drip::Client::EventsTest < Drip::TestCase
   context "#event_actions" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/event_actions" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/event_actions").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/forms_test.rb
+++ b/test/drip/client/forms_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::FormsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#forms" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/forms" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/forms").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -31,12 +23,11 @@ class Drip::Client::FormsTest < Drip::TestCase
   context "#form" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 9999999
 
-      @stubs.get "12345/forms/#{@id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/forms/#{@id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/orders_test.rb
+++ b/test/drip/client/orders_test.rb
@@ -2,14 +2,7 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::OrdersTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#create_or_update_order" do
@@ -31,11 +24,10 @@ class Drip::Client::OrdersTest < Drip::TestCase
       }
       @payload = { "orders" => [@options] }.to_json
       @response_status = 202
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/orders", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/orders").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the correct request" do
@@ -79,11 +71,10 @@ class Drip::Client::OrdersTest < Drip::TestCase
 
       @payload = { "batches" => [{ "orders" => @orders }] }.to_json
       @response_status = 202
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/orders/batches", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/orders/batches").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the correct request" do
@@ -105,11 +96,10 @@ class Drip::Client::OrdersTest < Drip::TestCase
 
       @payload = { "refunds" => [@options] }.to_json
       @response_status = 202
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/refunds", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/refunds").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the correct request" do

--- a/test/drip/client/purchases_test.rb
+++ b/test/drip/client/purchases_test.rb
@@ -2,14 +2,7 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::PurchasesTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#create_purchase" do
@@ -32,11 +25,10 @@ class Drip::Client::PurchasesTest < Drip::TestCase
       }
       @payload = { "orders" => [@options] }.to_json
       @response_status = 202
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/orders", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/orders").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/subscribers_test.rb
+++ b/test/drip/client/subscribers_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::SubscribersTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#subscribers" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/subscribers" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/subscribers").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -32,11 +24,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
     setup do
       @id = "derrick@getdrip.com"
       @response_status = 201
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/subscribers/#{CGI.escape @id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/subscribers/#{CGI.escape @id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -49,11 +40,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
     setup do
       @id = "derrick@getdrip.com"
       @response_status = 204
-      @response_body = stub
+      @response_body = nil
 
-      @stubs.delete "12345/subscribers/#{CGI.escape @id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:delete, "https://api.getdrip.com/v2/12345/subscribers/#{CGI.escape @id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -69,11 +59,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
       @payload = { "subscribers" => [@data.merge(email: @email)] }.to_json
 
       @response_status = 201
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/subscribers", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/subscribers").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -97,11 +86,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
 
       @payload = { "batches" => [{ "subscribers" => @subscribers }] }.to_json
       @response_status = 201
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/subscribers/batches", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/subscribers/batches").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -123,11 +111,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
 
       @payload = { "batches" => [{ "subscribers" => @subscribers }] }.to_json
       @response_status = 204
-      @response_body = stub
+      @response_body = nil
 
-      @stubs.post "12345/unsubscribes/batches", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/unsubscribes/batches").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -144,11 +131,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
       @payload = { "subscribers" => [@data.merge(email: @email)] }.to_json
 
       @response_status = 201
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/campaigns/#{@campaign_id}/subscribers", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/campaigns/#{@campaign_id}/subscribers").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -163,11 +149,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
         @id = "derrick@getdrip.com"
 
         @response_status = 201
-        @response_body = stub
+        @response_body = "stub"
 
-        @stubs.post "12345/subscribers/#{CGI.escape @id}/remove" do
-          [@response_status, {}, @response_body]
-        end
+        stub_request(:post, "https://api.getdrip.com/v2/12345/subscribers/#{CGI.escape @id}/remove").
+          to_return(status: @response_status, body: @response_body, headers: {})
       end
 
       should "send the right request" do
@@ -182,11 +167,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
         @campaign = "12345"
 
         @response_status = 201
-        @response_body = stub
+        @response_body = "stub"
 
-        @stubs.post "12345/subscribers/#{CGI.escape @id}/remove?campaign_id=#{@campaign}" do
-          [@response_status, {}, @response_body]
-        end
+        stub_request(:post, "https://api.getdrip.com/v2/12345/subscribers/#{CGI.escape @id}/remove?campaign_id=#{@campaign}").
+          to_return(status: @response_status, body: @response_body, headers: {})
       end
 
       should "send the right request" do
@@ -200,11 +184,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
     setup do
       @id = "derrick@getdrip.com"
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/subscribers/#{CGI.escape @id}/unsubscribe_all" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/subscribers/#{CGI.escape @id}/unsubscribe_all").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -220,11 +203,10 @@ class Drip::Client::SubscribersTest < Drip::TestCase
       @payload = { "tags" => [{ "email" => @email, "tag" => @tag }] }.to_json
 
       @response_status = 201
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/tags", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/tags").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/tags_test.rb
+++ b/test/drip/client/tags_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::TagsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#tags" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/tags" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/tags").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -35,11 +27,10 @@ class Drip::Client::TagsTest < Drip::TestCase
       @payload = { "tags" => [{ "email" => @email, "tag" => @tag }] }.to_json
 
       @response_status = 201
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/tags", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/tags").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -54,11 +45,10 @@ class Drip::Client::TagsTest < Drip::TestCase
       @tag = "Customer"
 
       @response_status = 204
-      @response_body = stub
+      @response_body = nil
 
-      @stubs.delete "12345/subscribers/#{CGI.escape @email}/tags/#{CGI.escape @tag}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:delete, "https://api.getdrip.com/v2/12345/subscribers/#{CGI.escape @email}/tags/#{CGI.escape @tag}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/webhooks_test.rb
+++ b/test/drip/client/webhooks_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::WebhooksTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#webhooks" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/webhooks" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/webhooks").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -31,12 +23,11 @@ class Drip::Client::WebhooksTest < Drip::TestCase
   context "#webhook" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 1234
 
-      @stubs.get "12345/webhooks/#{@id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/webhooks/#{@id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -59,11 +50,10 @@ class Drip::Client::WebhooksTest < Drip::TestCase
 
       @payload = { "webhooks" => [@options] }.to_json
       @response_status = 201
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/webhooks", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/webhooks").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -75,12 +65,11 @@ class Drip::Client::WebhooksTest < Drip::TestCase
   context "#delete_webhook" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 1234
 
-      @stubs.delete "12345/webhooks/#{@id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:delete, "https://api.getdrip.com/v2/12345/webhooks/#{@id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/workflow_triggers_test.rb
+++ b/test/drip/client/workflow_triggers_test.rb
@@ -2,25 +2,17 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::WorkflowTriggersTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#workflow_triggers" do
     setup do
       @id = 9999999
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/workflows/#{@id}/triggers" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/workflows/#{@id}/triggers").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -43,11 +35,10 @@ class Drip::Client::WorkflowTriggersTest < Drip::TestCase
       @payload = { "triggers" => [@data] }.to_json
 
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.post "12345/workflows/#{@id}/triggers", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/workflows/#{@id}/triggers").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -70,11 +61,10 @@ class Drip::Client::WorkflowTriggersTest < Drip::TestCase
       @payload = { "triggers" => [@data] }.to_json
 
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.put "12345/workflows/#{@id}/triggers", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:put, "https://api.getdrip.com/v2/12345/workflows/#{@id}/triggers").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client/workflows_test.rb
+++ b/test/drip/client/workflows_test.rb
@@ -2,24 +2,16 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 
 class Drip::Client::WorkflowsTest < Drip::TestCase
   def setup
-    @stubs = Faraday::Adapter::Test::Stubs.new
-
-    @connection = Faraday.new do |builder|
-      builder.adapter :test, @stubs
-    end
-
     @client = Drip::Client.new { |c| c.account_id = "12345" }
-    @client.expects(:connection).at_least_once.returns(@connection)
   end
 
   context "#workflows" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
 
-      @stubs.get "12345/workflows" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/workflows").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -31,12 +23,11 @@ class Drip::Client::WorkflowsTest < Drip::TestCase
   context "#workflow" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 1234
 
-      @stubs.get "12345/workflows/#{@id}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:get, "https://api.getdrip.com/v2/12345/workflows/#{@id}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -48,12 +39,11 @@ class Drip::Client::WorkflowsTest < Drip::TestCase
   context "#activate_workflow" do
     setup do
       @response_status = 204
-      @response_body = stub
+      @response_body = nil
       @id = 1234
 
-      @stubs.post "12345/workflows/#{@id}/activate" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/workflows/#{@id}/activate").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -65,12 +55,11 @@ class Drip::Client::WorkflowsTest < Drip::TestCase
   context "#pause_workflow" do
     setup do
       @response_status = 204
-      @response_body = stub
+      @response_body = nil
       @id = 1234
 
-      @stubs.post "12345/workflows/#{@id}/pause" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/workflows/#{@id}/pause").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -89,11 +78,10 @@ class Drip::Client::WorkflowsTest < Drip::TestCase
       @payload = { "subscribers" => [@data] }.to_json
 
       @response_status = 204
-      @response_body = stub
+      @response_body = nil
 
-      @stubs.post "12345/workflows/#{@id}/subscribers", @payload do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:post, "https://api.getdrip.com/v2/12345/workflows/#{@id}/subscribers").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do
@@ -105,13 +93,12 @@ class Drip::Client::WorkflowsTest < Drip::TestCase
   context "#remove_subscriber_workflow" do
     setup do
       @response_status = 200
-      @response_body = stub
+      @response_body = "stub"
       @id = 1234
       @email = "someone@example.com"
 
-      @stubs.delete "12345/workflows/#{@id}/subscribers/#{CGI.escape @email}" do
-        [@response_status, {}, @response_body]
-      end
+      stub_request(:delete, "https://api.getdrip.com/v2/12345/workflows/#{@id}/subscribers/#{CGI.escape @email}").
+        to_return(status: @response_status, body: @response_body, headers: {})
     end
 
     should "send the right request" do

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -74,8 +74,13 @@ class Drip::ClientTest < Drip::TestCase
     end
 
     should "use Basic authentication" do
+      stub_request(:get, "https://api.getdrip.com/v2/testpath").
+        to_return(status: 200, body: "", headers: {})
+
+      @client.get("testpath")
+
       header = "Basic #{Base64.encode64(@key + ":")}".strip
-      assert_equal header, @client.connection.headers["Authorization"]
+      assert_requested :get, "https://api.getdrip.com/v2/testpath", headers: { 'Authorization' => header }
     end
   end
 
@@ -90,7 +95,11 @@ class Drip::ClientTest < Drip::TestCase
     end
 
     should "connect to alternate prefix" do
-      assert_equal @url_prefix, @client.connection.url_prefix.to_s
+      stub_request(:get, "https://api.example.com/v9001/testpath").
+        to_return(status: 200, body: "", headers: {})
+      @client.get("testpath")
+
+      assert_requested :get, "https://api.example.com/v9001/testpath"
     end
   end
 
@@ -103,8 +112,11 @@ class Drip::ClientTest < Drip::TestCase
     end
 
     should "use Bearer token authentication" do
+      stub_request(:get, "https://api.getdrip.com/v2/testpath").
+        to_return(status: 200, body: "", headers: {})
+      @client.get("testpath")
       header = "Bearer #{@key}"
-      assert_equal header, @client.connection.headers["Authorization"]
+      assert_requested :get, "https://api.getdrip.com/v2/testpath", headers: { 'Authorization' => header }
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,14 +4,7 @@ require "drip"
 require "minitest/autorun"
 require "shoulda-context"
 require "mocha/setup"
-# require "webmock/minitest"
-# require "vcr"
-require "faraday"
-
-# VCR.configure do |c|
-#   c.cassette_library_dir = 'test/cassettes'
-#   c.hook_into :webmock # or :fakeweb
-# end
+require "webmock/minitest"
 
 class Drip::TestCase < Minitest::Test
   def expand_fixture_path(path)


### PR DESCRIPTION
First draft of using `Net::HTTP` directly and skipping Faraday. Avoids version conflicts that we and our customers are seeing.