### PR TITLE
Check verb_klass for equality so it does not set request body on GET

### DIFF
--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -84,13 +84,13 @@ module Drip
 
       build_response do
         Net::HTTP.start(uri.host, uri.port, connection_options(uri.scheme)) do |http|
-          if verb_klass.is_a? Net::HTTP::Get
+          if verb_klass == Net::HTTP::Get
             uri.query = URI.encode_www_form(options)
           end
 
           request = verb_klass.new uri
 
-          unless verb_klass.is_a? Net::HTTP::Get
+          unless verb_klass == Net::HTTP::Get
             request.body = options.to_json
           end
 

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -150,4 +150,34 @@ class Drip::ClientTest < Drip::TestCase
       assert_requested :get, "https://api.example.com/mytestpath", times: 5
     end
   end
+
+  context "given a get request" do
+    setup do
+      @client = Drip::Client.new
+      @response = mock
+      @response.stubs(:code).returns('200')
+      @response.stubs(:body).returns('mybody')
+
+      @http = mock
+      @http.expects(:request).returns(@response)
+
+      @request = mock
+      @request.stubs(:[]=)
+      @request.stubs(:basic_auth)
+    end
+
+    should "encode query and not set body" do
+      stub_request(:get, "https://api.getdrip.com/v2/testpath").
+        to_return(status: 200, body: "mybody")
+
+      Net::HTTP::Get.expects(:new).returns(@request)
+      Net::HTTP.expects(:start).yields(@http).returns(@response)
+
+      @request.expects(:body=).never
+      URI.expects(:encode_www_form).once
+
+      response = @client.get("testpath")
+      assert_equal "mybody", response.body
+    end
+  end
 end


### PR DESCRIPTION
In Ruby 2.1.5 and in Ruby 2.4.1, when I run the following: 

```
require "drip"
client = Drip::Client.new do |c|
  c.api_key = "MY_TOKEN"
end
client.accounts
```

I get

```
#<Drip::Response:0x00556da295a028
 @body=
  "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"
 \"http://www.w3.org/TR/html4/loose.dtd\">\n<HTML><HEAD><META HTTP-EQUIV=\"Content-Type\"
 CONTENT=\"text/html; charset=iso-8859-1\">\n<TITLE>ERROR: The request could not be 
satisfied</TITLE>\n</HEAD><BODY>\n<H1>403 ERROR</H1>\n<H2>The request could not be
 satisfied.</H2>\n<HR noshade size=\"1px\">\nBad request.\n\n<BR clear=\"all\">\n<HR noshade
 size=\"1px\">\n<PRE>\nGenerated by cloudfront (CloudFront)\nRequest ID:
 [REDACTED]==\n</PRE>\n<ADDRESS>\n</ADDRESS>\n</BODY></HTML>",
 @links=nil,
 @members={},
 @meta=nil,
 @status=403>
```

This seems to be caused by the fact that the GET request has a body set on it, because the check on whether the request is a GET fails as `is_a?` checks for class of object, not actual object.

```
[3] pry(main)> Net::HTTP::Get.is_a?(Net::HTTP::Get)
=> false
```

I prepared a test case which illustrates the issue and a proposed fix. If there is another solution, I'd appreciate a suggestion. Thanks!