### PR TITLE
Fix collection of strings assuming complex objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [master]: https://github.com/DripEmail/drip-ruby/compare/v3.1.1...HEAD
 
 - Allow `#create_or_update_subscriber` to work with Drip id. Fixes [#50](https://github.com/DripEmail/drip-ruby/issues/50)
+- [#52](https://github.com/DripEmail/drip-ruby/pull/52): Fix `#custom_fields` to accept the API response without error. Fixes [#30](https://github.com/DripEmail/drip-ruby/issues/30)
 - Your contribution here!
 
 ## [3.1.1] - 2018-06-06

--- a/lib/drip/collection.rb
+++ b/lib/drip/collection.rb
@@ -24,7 +24,7 @@ module Drip
 
     def parse_items
       raw_items.map do |raw_item|
-        item_class.new(raw_item)
+        raw_item.is_a?(String) ? raw_item : item_class.new(raw_item)
       end
     end
 

--- a/test/drip/client/custom_fields_test.rb
+++ b/test/drip/client/custom_fields_test.rb
@@ -8,7 +8,15 @@ class Drip::Client::CustomFieldsTest < Drip::TestCase
   context "#custom_fields" do
     setup do
       @response_status = 200
-      @response_body = "{}"
+      @response_body = <<-JSON
+        {
+          "custom_field_identifiers":[
+            "custom_field_1",
+            "custom_field_2",
+            "custom_field_3"
+          ]
+        }
+      JSON
 
       stub_request(:get, "https://api.getdrip.com/v2/12345/custom_field_identifiers").
         to_return(status: @response_status, body: @response_body, headers: {})


### PR DESCRIPTION
Fixes https://github.com/DripEmail/drip-ruby/issues/30

`custom_field_identifiers` is an array of strings. Collections assume substructures right now, which isn't the case here.