### PR TITLE
Stop assuming v2 endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [master]: https://github.com/DripEmail/drip-ruby/compare/v3.2.0...HEAD
 
+### Changed
+- `Drip::Client#url_prefix` parameter no longer includes `/vN` part of the URL in order to prepare for Shopper Activity API. This breaks backwards compatibility for this option, but there is no expected production usage of this parameter.
+- `Drip::Client#get`, `Drip::Client#post`, `Drip::Client#put`, and `Drip::Client#delete` methods no longer auto-prepend `/v2` if the given path starts with `v2/` or `v3/`. This behavior is deprecated and will produce a warning. If you are using one of these methods and get this warning, just add `v2/` to the beginning of the path when you call it.
+
+### Removed
 - Drop support for Ruby 2.1.
 
 - Your contribution here!

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -43,7 +43,7 @@ module Drip
       @account_id = options[:account_id]
       @access_token = options[:access_token]
       @api_key = options[:api_key]
-      @url_prefix = options[:url_prefix] || "https://api.getdrip.com/v2/"
+      @url_prefix = options[:url_prefix] || "https://api.getdrip.com/"
       @http_open_timeout = options[:http_open_timeout]
       @http_timeout = options[:http_timeout]
       yield(self) if block_given?
@@ -76,6 +76,10 @@ module Drip
   private
 
     def make_uri(path)
+      if !path.start_with?("v2/") && !path.start_with?("v3/")
+        warn "[DEPRECATED] Automatically prepended path with 'v2/'"
+        path = "v2/#{path}"
+      end
       URI(url_prefix) + URI(path)
     end
 

--- a/lib/drip/client/accounts.rb
+++ b/lib/drip/client/accounts.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#accounts
       def accounts
-        get "accounts"
+        get "v2/accounts"
       end
 
       # Public: Fetch an account.
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#accounts
       def account(id)
-        get "accounts/#{id}"
+        get "v2/accounts/#{id}"
       end
     end
   end

--- a/lib/drip/client/broadcasts.rb
+++ b/lib/drip/client/broadcasts.rb
@@ -12,7 +12,7 @@ module Drip
       # Returns a Drip::Response
       # See https://www.getdrip.com/docs/rest-api#broadcasts
       def broadcasts(options = {})
-        get "#{account_id}/broadcasts", options
+        get "v2/#{account_id}/broadcasts", options
       end
 
       # Public: Fetch a broadcast.
@@ -22,7 +22,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#broadcasts
       def broadcast(id)
-        get "#{account_id}/broadcasts/#{id}"
+        get "v2/#{account_id}/broadcasts/#{id}"
       end
     end
   end

--- a/lib/drip/client/campaign_subscriptions.rb
+++ b/lib/drip/client/campaign_subscriptions.rb
@@ -8,7 +8,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs.rest-api#campaign_subscriptions
       def campaign_subscriptions(subscriber_id)
-        get "#{account_id}/subscribers/#{subscriber_id}/campaign_subscriptions"
+        get "v2/#{account_id}/subscribers/#{subscriber_id}/campaign_subscriptions"
       end
     end
   end

--- a/lib/drip/client/campaigns.rb
+++ b/lib/drip/client/campaigns.rb
@@ -14,7 +14,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs.rest-api#campaigns
       def campaigns(options = {})
-        get "#{account_id}/campaigns", options
+        get "v2/#{account_id}/campaigns", options
       end
 
       # Public: Fetch a campaign.
@@ -24,7 +24,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def campaign(id)
-        get "#{account_id}/campaigns/#{id}"
+        get "v2/#{account_id}/campaigns/#{id}"
       end
 
       # Public: Activate a campaign.
@@ -34,7 +34,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def activate_campaign(id)
-        post "#{account_id}/campaigns/#{id}/activate"
+        post "v2/#{account_id}/campaigns/#{id}/activate"
       end
 
       # Public: Pause a campaign.
@@ -44,7 +44,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def pause_campaign(id)
-        post "#{account_id}/campaigns/#{id}/pause"
+        post "v2/#{account_id}/campaigns/#{id}/pause"
       end
 
       # Public: List everyone subscribed to a campaign.
@@ -68,7 +68,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def campaign_subscribers(id, options = {})
-        get "#{account_id}/campaigns/#{id}/subscribers", options
+        get "v2/#{account_id}/campaigns/#{id}/subscribers", options
       end
     end
   end

--- a/lib/drip/client/conversions.rb
+++ b/lib/drip/client/conversions.rb
@@ -10,7 +10,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#conversions
       def conversions(options = {})
-        get "#{account_id}/goals", options
+        get "v2/#{account_id}/goals", options
       end
 
       # Public: Fetch a conversion.
@@ -20,7 +20,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#conversions
       def conversion(id)
-        get "#{account_id}/goals/#{id}"
+        get "v2/#{account_id}/goals/#{id}"
       end
     end
   end

--- a/lib/drip/client/custom_fields.rb
+++ b/lib/drip/client/custom_fields.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#custom_fields
       def custom_fields
-        get "#{account_id}/custom_field_identifiers"
+        get "v2/#{account_id}/custom_field_identifiers"
       end
     end
   end

--- a/lib/drip/client/events.rb
+++ b/lib/drip/client/events.rb
@@ -14,7 +14,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#record_event
       def track_event(email, action, properties = {}, options = {})
         data = options.merge({ "email" => email, "action" => action, "properties" => properties })
-        post "#{account_id}/events", generate_resource("events", data)
+        post "v2/#{account_id}/events", generate_resource("events", data)
       end
 
       # Public: Track a collection of events all at once.
@@ -27,7 +27,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#event_batches
       def track_events(events)
-        url = "#{account_id}/events/batches"
+        url = "v2/#{account_id}/events/batches"
         post url, generate_resource("batches", { "events" => events })
       end
 
@@ -41,7 +41,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#events
       def event_actions(options = {})
-        get "#{account_id}/event_actions", options
+        get "v2/#{account_id}/event_actions", options
       end
     end
   end

--- a/lib/drip/client/forms.rb
+++ b/lib/drip/client/forms.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#forms
       def forms
-        get "#{account_id}/forms"
+        get "v2/#{account_id}/forms"
       end
 
       # Public: Fetch a form.
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#forms
       def form(id)
-        get "#{account_id}/forms/#{id}"
+        get "v2/#{account_id}/forms/#{id}"
       end
     end
   end

--- a/lib/drip/client/orders.rb
+++ b/lib/drip/client/orders.rb
@@ -11,7 +11,7 @@ module Drip
       # See https://developer.drip.com/#orders
       def create_or_update_order(email, options = {})
         data = options.merge(email: email)
-        post "#{account_id}/orders", generate_resource("orders", data)
+        post "v2/#{account_id}/orders", generate_resource("orders", data)
       end
 
       # Public: Create or update a batch of orders.
@@ -21,7 +21,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-batch-of-orders
       def create_or_update_orders(orders)
-        post "#{account_id}/orders/batches", generate_resource("batches", { "orders" => orders })
+        post "v2/#{account_id}/orders/batches", generate_resource("batches", { "orders" => orders })
       end
 
       # Public: Create or update a refund.
@@ -38,7 +38,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-refund
       def create_or_update_refund(options)
-        post "#{account_id}/refunds", generate_resource("refunds", options)
+        post "v2/#{account_id}/refunds", generate_resource("refunds", options)
       end
     end
   end

--- a/lib/drip/client/subscribers.rb
+++ b/lib/drip/client/subscribers.rb
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#list_subscribers
       def subscribers(options = {})
-        get "#{account_id}/subscribers", options
+        get "v2/#{account_id}/subscribers", options
       end
 
       # Public: Fetch a subscriber.
@@ -26,7 +26,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#fetch_subscriber
       def subscriber(id_or_email)
-        get "#{account_id}/subscribers/#{CGI.escape id_or_email}"
+        get "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
       end
 
       # Public: Create or update a subscriber.
@@ -51,7 +51,7 @@ module Drip
         data[:email] = args[0] if args[0].is_a? String
         data.merge!(args.last) if args.last.is_a? Hash
         raise ArgumentError, 'email: or id: parameter required' if !data.key?(:email) && !data.key?(:id)
-        post "#{account_id}/subscribers", generate_resource("subscribers", data)
+        post "v2/#{account_id}/subscribers", generate_resource("subscribers", data)
       end
 
       # Public: Create or update a collection of subscribers.
@@ -70,7 +70,7 @@ module Drip
       # Returns a Drip::Response
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def create_or_update_subscribers(subscribers)
-        url = "#{account_id}/subscribers/batches"
+        url = "v2/#{account_id}/subscribers/batches"
         post url, generate_resource("batches", { "subscribers" => subscribers })
       end
 
@@ -82,7 +82,7 @@ module Drip
       # Returns a Drip::Response
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def unsubscribe_subscribers(subscribers)
-        url = "#{account_id}/unsubscribes/batches"
+        url = "v2/#{account_id}/unsubscribes/batches"
         post url, generate_resource("batches", { "subscribers" => subscribers })
       end
 
@@ -96,7 +96,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#unsubscribe
       def unsubscribe(id_or_email, options = {})
-        url = "#{account_id}/subscribers/#{CGI.escape id_or_email}/remove"
+        url = "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/remove"
         url += options[:campaign_id] ? "?campaign_id=#{options[:campaign_id]}" : ""
         post url
       end
@@ -126,7 +126,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscribe
       def subscribe(email, campaign_id, options = {})
         data = options.merge("email" => email)
-        url = "#{account_id}/campaigns/#{campaign_id}/subscribers"
+        url = "v2/#{account_id}/campaigns/#{campaign_id}/subscribers"
         post url, generate_resource("subscribers", data)
       end
 
@@ -137,7 +137,7 @@ module Drip
       # Returns No Content.
       # See https://www.getdrip.com/docs/rest-api#fdelete_subscriber
       def delete_subscriber(id_or_email)
-        delete "#{account_id}/subscribers/#{CGI.escape id_or_email}"
+        delete "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
       end
 
       # Public: Unsubscribe a subscriber from all mailings.
@@ -147,7 +147,7 @@ module Drip
       # Returns No Content.
       # See https://www.getdrip.com/docs/rest-api#fdelete_subscriber
       def unsubscribe_from_all(id_or_email)
-        post "#{account_id}/subscribers/#{CGI.escape id_or_email}/unsubscribe_all"
+        post "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/unsubscribe_all"
       end
     end
   end

--- a/lib/drip/client/tags.rb
+++ b/lib/drip/client/tags.rb
@@ -8,7 +8,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#tags
       def tags
-        get "#{account_id}/tags"
+        get "v2/#{account_id}/tags"
       end
 
       # Public: Apply a tag to a subscriber.
@@ -20,7 +20,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#apply_tag
       def apply_tag(email, tag)
         data = { "email" => email, "tag" => tag }
-        post "#{account_id}/tags", generate_resource("tags", data)
+        post "v2/#{account_id}/tags", generate_resource("tags", data)
       end
 
       # Public: Remove a tag from a subscriber.
@@ -31,7 +31,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#remove_tag
       def remove_tag(email, tag)
-        delete "#{account_id}/subscribers/#{CGI.escape email}/tags/#{CGI.escape tag}"
+        delete "v2/#{account_id}/subscribers/#{CGI.escape email}/tags/#{CGI.escape tag}"
       end
     end
   end

--- a/lib/drip/client/webhooks.rb
+++ b/lib/drip/client/webhooks.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def webhooks
-        get "#{account_id}/webhooks"
+        get "v2/#{account_id}/webhooks"
       end
 
       # Public: Fetch a webhook
@@ -15,7 +15,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def webhook(id)
-        get "#{account_id}/webhooks/#{id}"
+        get "v2/#{account_id}/webhooks/#{id}"
       end
 
       # Public: Create a webhook.
@@ -34,7 +34,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def create_webhook(post_url, include_received_email, events)
         include_received_email = include_received_email ? true : false
-        url = "#{account_id}/webhooks"
+        url = "v2/#{account_id}/webhooks"
 
         post url, generate_resource(
           "webhooks",
@@ -52,7 +52,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def delete_webhook(id)
-        delete "#{account_id}/webhooks/#{id}"
+        delete "v2/#{account_id}/webhooks/#{id}"
       end
     end
   end

--- a/lib/drip/client/workflow_triggers.rb
+++ b/lib/drip/client/workflow_triggers.rb
@@ -7,7 +7,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflow_triggers
       def workflow_triggers(id)
-        get "#{account_id}/workflows/#{id}/triggers"
+        get "v2/#{account_id}/workflows/#{id}/triggers"
       end
 
       # Public: Create a workflow trigger.
@@ -22,7 +22,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def create_workflow_trigger(id, options = {})
-        post "#{account_id}/workflows/#{id}/triggers", generate_resource("triggers", options)
+        post "v2/#{account_id}/workflows/#{id}/triggers", generate_resource("triggers", options)
       end
 
       # Public: Update a workflow trigger.
@@ -37,7 +37,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def update_workflow_trigger(id, options = {})
-        put "#{account_id}/workflows/#{id}/triggers", generate_resource("triggers", options)
+        put "v2/#{account_id}/workflows/#{id}/triggers", generate_resource("triggers", options)
       end
     end
   end

--- a/lib/drip/client/workflows.rb
+++ b/lib/drip/client/workflows.rb
@@ -12,7 +12,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def workflows(options = {})
-        get "#{account_id}/workflows", options
+        get "v2/#{account_id}/workflows", options
       end
 
       # Public: Fetch a workflow.
@@ -21,7 +21,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def workflow(id)
-        get "#{account_id}/workflows/#{id}"
+        get "v2/#{account_id}/workflows/#{id}"
       end
 
       # Public: Activate a workflow.
@@ -30,7 +30,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def activate_workflow(id)
-        post "#{account_id}/workflows/#{id}/activate"
+        post "v2/#{account_id}/workflows/#{id}/activate"
       end
 
       # Public: Pause a workflow.
@@ -39,7 +39,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def pause_workflow(id)
-        post "#{account_id}/workflows/#{id}/pause"
+        post "v2/#{account_id}/workflows/#{id}/pause"
       end
 
       # Public: Start someone on a workflow.
@@ -63,7 +63,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def start_subscriber_workflow(id, options = {})
-        post "#{account_id}/workflows/#{id}/subscribers", generate_resource("subscribers", options)
+        post "v2/#{account_id}/workflows/#{id}/subscribers", generate_resource("subscribers", options)
       end
 
       # Public: Remove someone from a workflow.
@@ -73,7 +73,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def remove_subscriber_workflow(workflow_id, id_or_email)
-        delete "#{account_id}/workflows/#{workflow_id}/subscribers/#{CGI.escape id_or_email}"
+        delete "v2/#{account_id}/workflows/#{workflow_id}/subscribers/#{CGI.escape id_or_email}"
       end
     end
   end


### PR DESCRIPTION
This prepares the way to support `v3` Shopper Activity endpoints.

Related to https://github.com/DripEmail/drip-ruby/issues/55

## Backwards compatibility notes
This does potentially break backwards compatibility in the combination of setting `url_prefix` and calling `#get`, `#post`, `#put`, and `#delete` manually. This combination is undocumented to the best of my knowledge. Some examples:

This case would be backwards incompatible and would request `https://api.getdrip.com/v2/v2/accounts`
```ruby
client = Drip::Client.new do |config|
  config.api_key = "abc123"
  config.url_prefix = "https://api.getdrip.com/v2/"
end

client.get("accounts")
```

However, if you use it as follows, it will request `https://api.getdrip.com/v2/accounts` and print a deprecation warning.
```ruby
client = Drip::Client.new do |config|
  config.api_key = "abc123"
end

client.get("accounts")
```

The new way to call it is as follows, which will not auto-prepend the version string.
```ruby
client = Drip::Client.new do |config|
  config.api_key = "abc123"
end

client.get("v2/accounts")
```

In general, most people will want to call the endpoint specific methods and not use these http verb methods directly.