### PR TITLE
Refactor request data clumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Drip::Client#content_type` is deprecated and will be removed in a future version. It is no longer used internally, effective immediately.
 - When using the block form of parameter initialization, a configuration object is provided instead of the client itself.
 - Calling configuration setters on `Drip::Client` is deprecated.
+- `Drip::Client::REDIRECT_LIMIT` constant is now private. This is supposed to be an implementation detail and shouldn't leak.
 
 ### Removed
 - Drop support for Ruby 2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - `Drip::Client#url_prefix` parameter no longer includes `/vN` part of the URL in order to prepare for Shopper Activity API. This breaks backwards compatibility for this option, but there is no expected production usage of this parameter.
-- `Drip::Client#get`, `Drip::Client#post`, `Drip::Client#put`, and `Drip::Client#delete` methods no longer auto-prepend `/v2` if the given path starts with `v2/` or `v3/`. This behavior is deprecated and will produce a warning. If you are using one of these methods and get this warning, just add `v2/` to the beginning of the path when you call it.
+- `Drip::Client#get`, `Drip::Client#post`, `Drip::Client#put`, and `Drip::Client#delete` are deprecated. If you are using these to hit a Drip API endpoint, please file a ticket or PR to fix the use case.
 - `Drip::Client#generate_resource` is deprecated and will be removed in a future version.
 - `Drip::Client#content_type` is deprecated and will be removed in a future version. It is no longer used internally, effective immediately.
 - When using the block form of parameter initialization, a configuration object is provided instead of the client itself.

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -38,9 +38,6 @@ module Drip
     include Workflows
     include WorkflowTriggers
 
-    REDIRECT_LIMIT = 10
-    private_constant :REDIRECT_LIMIT
-
     Drip::Client::Configuration::CONFIGURATION_FIELDS.each do |config_key|
       define_method(config_key) do
         @config.public_send(config_key)

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -1,4 +1,5 @@
 require "drip/errors"
+require "drip/request"
 require "drip/response"
 require "drip/client/accounts"
 require "drip/client/broadcasts"

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -73,7 +73,7 @@ module Drip
     Drip::Request::VERB_CLASS_MAPPING.keys.each do |verb|
       define_method(verb) do |path, options = {}|
         warn "[DEPRECATED] Drip::Client##{verb} please use the API endpoint specific methods"
-        make_request Drip::Request.new(verb, make_uri("v2/#{path}"), options, content_type)
+        make_request Drip::Request.new(verb, make_uri("v2/#{path}"), options, JSON_API_CONTENT_TYPE)
       end
     end
 

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -74,11 +74,15 @@ module Drip
     Drip::Request::VERB_CLASS_MAPPING.keys.each do |verb|
       define_method(verb) do |path, options = {}|
         warn "[DEPRECATED] Drip::Client##{verb} please use the API endpoint specific methods"
-        make_request Drip::Request.new(verb, make_uri("v2/#{path}"), options, JSON_API_CONTENT_TYPE)
+        make_v2_request(verb, "v2/#{path}", options)
       end
     end
 
   private
+
+    def make_v2_request(http_verb, path, options = {})
+      make_request Drip::Request.new(http_verb, make_uri(path), options, JSON_API_CONTENT_TYPE)
+    end
 
     def private_generate_resource(key, *args)
       # No reason for this to be part of the public API, so making a duplicate method to make it private.

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -71,9 +71,9 @@ module Drip
     end
 
     Drip::Request::VERB_CLASS_MAPPING.keys.each do |verb|
-      define_method(verb) do |url, options = {}|
+      define_method(verb) do |path, options = {}|
         warn "[DEPRECATED] Drip::Client##{verb} please use the API endpoint specific methods"
-        make_request Drip::Request.new(verb, make_uri(url), options, content_type)
+        make_request Drip::Request.new(verb, make_uri("v2/#{path}"), options, content_type)
       end
     end
 
@@ -85,10 +85,6 @@ module Drip
     end
 
     def make_uri(path)
-      if !path.start_with?("v2/") && !path.start_with?("v3/")
-        warn "[DEPRECATED] Automatically prepended path with 'v2/'"
-        path = "v2/#{path}"
-      end
       URI(@config.url_prefix) + URI(path)
     end
 

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -22,7 +22,7 @@ require "uri"
 require "json"
 
 module Drip
-  class Client # rubocop:disable Metrics/ClassLength
+  class Client
     include Accounts
     include Broadcasts
     include Campaigns

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -71,13 +71,13 @@ module Drip
     Drip::Request::VERB_CLASS_MAPPING.keys.each do |verb|
       define_method(verb) do |path, options = {}|
         warn "[DEPRECATED] Drip::Client##{verb} please use the API endpoint specific methods"
-        make_v2_request(verb, "v2/#{path}", options)
+        make_json_api_request(verb, "v2/#{path}", options)
       end
     end
 
   private
 
-    def make_v2_request(http_verb, path, options = {})
+    def make_json_api_request(http_verb, path, options = {})
       make_request Drip::Request.new(http_verb, make_uri(path), options, JSON_API_CONTENT_TYPE)
     end
 

--- a/lib/drip/client/accounts.rb
+++ b/lib/drip/client/accounts.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#accounts
       def accounts
-        get "v2/accounts"
+        make_request Drip::Request.new(:get, make_uri("v2/accounts"))
       end
 
       # Public: Fetch an account.
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#accounts
       def account(id)
-        get "v2/accounts/#{id}"
+        make_request Drip::Request.new(:get, make_uri("v2/accounts/#{id}"))
       end
     end
   end

--- a/lib/drip/client/accounts.rb
+++ b/lib/drip/client/accounts.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#accounts
       def accounts
-        make_v2_request :get, "v2/accounts"
+        make_json_api_request :get, "v2/accounts"
       end
 
       # Public: Fetch an account.
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#accounts
       def account(id)
-        make_v2_request :get, "v2/accounts/#{id}"
+        make_json_api_request :get, "v2/accounts/#{id}"
       end
     end
   end

--- a/lib/drip/client/accounts.rb
+++ b/lib/drip/client/accounts.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#accounts
       def accounts
-        make_request Drip::Request.new(:get, make_uri("v2/accounts"))
+        make_v2_request :get, "v2/accounts"
       end
 
       # Public: Fetch an account.
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#accounts
       def account(id)
-        make_request Drip::Request.new(:get, make_uri("v2/accounts/#{id}"))
+        make_v2_request :get, "v2/accounts/#{id}"
       end
     end
   end

--- a/lib/drip/client/broadcasts.rb
+++ b/lib/drip/client/broadcasts.rb
@@ -12,7 +12,7 @@ module Drip
       # Returns a Drip::Response
       # See https://www.getdrip.com/docs/rest-api#broadcasts
       def broadcasts(options = {})
-        get "v2/#{account_id}/broadcasts", options
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/broadcasts"), options)
       end
 
       # Public: Fetch a broadcast.
@@ -22,7 +22,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#broadcasts
       def broadcast(id)
-        get "v2/#{account_id}/broadcasts/#{id}"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/broadcasts/#{id}"))
       end
     end
   end

--- a/lib/drip/client/broadcasts.rb
+++ b/lib/drip/client/broadcasts.rb
@@ -12,7 +12,7 @@ module Drip
       # Returns a Drip::Response
       # See https://www.getdrip.com/docs/rest-api#broadcasts
       def broadcasts(options = {})
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/broadcasts"), options)
+        make_v2_request :get, "v2/#{account_id}/broadcasts", options
       end
 
       # Public: Fetch a broadcast.
@@ -22,7 +22,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#broadcasts
       def broadcast(id)
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/broadcasts/#{id}"))
+        make_v2_request :get, "v2/#{account_id}/broadcasts/#{id}"
       end
     end
   end

--- a/lib/drip/client/broadcasts.rb
+++ b/lib/drip/client/broadcasts.rb
@@ -12,7 +12,7 @@ module Drip
       # Returns a Drip::Response
       # See https://www.getdrip.com/docs/rest-api#broadcasts
       def broadcasts(options = {})
-        make_v2_request :get, "v2/#{account_id}/broadcasts", options
+        make_json_api_request :get, "v2/#{account_id}/broadcasts", options
       end
 
       # Public: Fetch a broadcast.
@@ -22,7 +22,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#broadcasts
       def broadcast(id)
-        make_v2_request :get, "v2/#{account_id}/broadcasts/#{id}"
+        make_json_api_request :get, "v2/#{account_id}/broadcasts/#{id}"
       end
     end
   end

--- a/lib/drip/client/campaign_subscriptions.rb
+++ b/lib/drip/client/campaign_subscriptions.rb
@@ -8,7 +8,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs.rest-api#campaign_subscriptions
       def campaign_subscriptions(subscriber_id)
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/subscribers/#{subscriber_id}/campaign_subscriptions"))
+        make_v2_request :get, "v2/#{account_id}/subscribers/#{subscriber_id}/campaign_subscriptions"
       end
     end
   end

--- a/lib/drip/client/campaign_subscriptions.rb
+++ b/lib/drip/client/campaign_subscriptions.rb
@@ -8,7 +8,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs.rest-api#campaign_subscriptions
       def campaign_subscriptions(subscriber_id)
-        make_v2_request :get, "v2/#{account_id}/subscribers/#{subscriber_id}/campaign_subscriptions"
+        make_json_api_request :get, "v2/#{account_id}/subscribers/#{subscriber_id}/campaign_subscriptions"
       end
     end
   end

--- a/lib/drip/client/campaign_subscriptions.rb
+++ b/lib/drip/client/campaign_subscriptions.rb
@@ -8,7 +8,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs.rest-api#campaign_subscriptions
       def campaign_subscriptions(subscriber_id)
-        get "v2/#{account_id}/subscribers/#{subscriber_id}/campaign_subscriptions"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/subscribers/#{subscriber_id}/campaign_subscriptions"))
       end
     end
   end

--- a/lib/drip/client/campaigns.rb
+++ b/lib/drip/client/campaigns.rb
@@ -14,7 +14,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs.rest-api#campaigns
       def campaigns(options = {})
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/campaigns"), options)
+        make_v2_request :get, "v2/#{account_id}/campaigns", options
       end
 
       # Public: Fetch a campaign.
@@ -24,7 +24,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def campaign(id)
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/campaigns/#{id}"))
+        make_v2_request :get, "v2/#{account_id}/campaigns/#{id}"
       end
 
       # Public: Activate a campaign.
@@ -34,7 +34,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def activate_campaign(id)
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/campaigns/#{id}/activate"))
+        make_v2_request :post, "v2/#{account_id}/campaigns/#{id}/activate"
       end
 
       # Public: Pause a campaign.
@@ -44,7 +44,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def pause_campaign(id)
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/campaigns/#{id}/pause"))
+        make_v2_request :post, "v2/#{account_id}/campaigns/#{id}/pause"
       end
 
       # Public: List everyone subscribed to a campaign.
@@ -68,7 +68,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def campaign_subscribers(id, options = {})
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/campaigns/#{id}/subscribers"), options)
+        make_v2_request :get, "v2/#{account_id}/campaigns/#{id}/subscribers", options
       end
     end
   end

--- a/lib/drip/client/campaigns.rb
+++ b/lib/drip/client/campaigns.rb
@@ -14,7 +14,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs.rest-api#campaigns
       def campaigns(options = {})
-        get "v2/#{account_id}/campaigns", options
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/campaigns"), options)
       end
 
       # Public: Fetch a campaign.
@@ -24,7 +24,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def campaign(id)
-        get "v2/#{account_id}/campaigns/#{id}"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/campaigns/#{id}"))
       end
 
       # Public: Activate a campaign.
@@ -34,7 +34,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def activate_campaign(id)
-        post "v2/#{account_id}/campaigns/#{id}/activate"
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/campaigns/#{id}/activate"))
       end
 
       # Public: Pause a campaign.
@@ -44,7 +44,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def pause_campaign(id)
-        post "v2/#{account_id}/campaigns/#{id}/pause"
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/campaigns/#{id}/pause"))
       end
 
       # Public: List everyone subscribed to a campaign.
@@ -68,7 +68,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def campaign_subscribers(id, options = {})
-        get "v2/#{account_id}/campaigns/#{id}/subscribers", options
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/campaigns/#{id}/subscribers"), options)
       end
     end
   end

--- a/lib/drip/client/campaigns.rb
+++ b/lib/drip/client/campaigns.rb
@@ -14,7 +14,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs.rest-api#campaigns
       def campaigns(options = {})
-        make_v2_request :get, "v2/#{account_id}/campaigns", options
+        make_json_api_request :get, "v2/#{account_id}/campaigns", options
       end
 
       # Public: Fetch a campaign.
@@ -24,7 +24,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def campaign(id)
-        make_v2_request :get, "v2/#{account_id}/campaigns/#{id}"
+        make_json_api_request :get, "v2/#{account_id}/campaigns/#{id}"
       end
 
       # Public: Activate a campaign.
@@ -34,7 +34,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def activate_campaign(id)
-        make_v2_request :post, "v2/#{account_id}/campaigns/#{id}/activate"
+        make_json_api_request :post, "v2/#{account_id}/campaigns/#{id}/activate"
       end
 
       # Public: Pause a campaign.
@@ -44,7 +44,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def pause_campaign(id)
-        make_v2_request :post, "v2/#{account_id}/campaigns/#{id}/pause"
+        make_json_api_request :post, "v2/#{account_id}/campaigns/#{id}/pause"
       end
 
       # Public: List everyone subscribed to a campaign.
@@ -68,7 +68,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#campaigns
       def campaign_subscribers(id, options = {})
-        make_v2_request :get, "v2/#{account_id}/campaigns/#{id}/subscribers", options
+        make_json_api_request :get, "v2/#{account_id}/campaigns/#{id}/subscribers", options
       end
     end
   end

--- a/lib/drip/client/conversions.rb
+++ b/lib/drip/client/conversions.rb
@@ -10,7 +10,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#conversions
       def conversions(options = {})
-        make_v2_request :get, "v2/#{account_id}/goals", options
+        make_json_api_request :get, "v2/#{account_id}/goals", options
       end
 
       # Public: Fetch a conversion.
@@ -20,7 +20,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#conversions
       def conversion(id)
-        make_v2_request :get, "v2/#{account_id}/goals/#{id}"
+        make_json_api_request :get, "v2/#{account_id}/goals/#{id}"
       end
     end
   end

--- a/lib/drip/client/conversions.rb
+++ b/lib/drip/client/conversions.rb
@@ -10,7 +10,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#conversions
       def conversions(options = {})
-        get "v2/#{account_id}/goals", options
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/goals"), options)
       end
 
       # Public: Fetch a conversion.
@@ -20,7 +20,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#conversions
       def conversion(id)
-        get "v2/#{account_id}/goals/#{id}"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/goals/#{id}"))
       end
     end
   end

--- a/lib/drip/client/conversions.rb
+++ b/lib/drip/client/conversions.rb
@@ -10,7 +10,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#conversions
       def conversions(options = {})
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/goals"), options)
+        make_v2_request :get, "v2/#{account_id}/goals", options
       end
 
       # Public: Fetch a conversion.
@@ -20,7 +20,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#conversions
       def conversion(id)
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/goals/#{id}"))
+        make_v2_request :get, "v2/#{account_id}/goals/#{id}"
       end
     end
   end

--- a/lib/drip/client/custom_fields.rb
+++ b/lib/drip/client/custom_fields.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#custom_fields
       def custom_fields
-        make_v2_request :get, "v2/#{account_id}/custom_field_identifiers"
+        make_json_api_request :get, "v2/#{account_id}/custom_field_identifiers"
       end
     end
   end

--- a/lib/drip/client/custom_fields.rb
+++ b/lib/drip/client/custom_fields.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#custom_fields
       def custom_fields
-        get "v2/#{account_id}/custom_field_identifiers"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/custom_field_identifiers"))
       end
     end
   end

--- a/lib/drip/client/custom_fields.rb
+++ b/lib/drip/client/custom_fields.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#custom_fields
       def custom_fields
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/custom_field_identifiers"))
+        make_v2_request :get, "v2/#{account_id}/custom_field_identifiers"
       end
     end
   end

--- a/lib/drip/client/events.rb
+++ b/lib/drip/client/events.rb
@@ -14,7 +14,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#record_event
       def track_event(email, action, properties = {}, options = {})
         data = options.merge({ "email" => email, "action" => action, "properties" => properties })
-        make_v2_request :post, "v2/#{account_id}/events", private_generate_resource("events", data)
+        make_json_api_request :post, "v2/#{account_id}/events", private_generate_resource("events", data)
       end
 
       # Public: Track a collection of events all at once.
@@ -28,7 +28,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#event_batches
       def track_events(events)
         url = "v2/#{account_id}/events/batches"
-        make_v2_request :post, url, private_generate_resource("batches", { "events" => events })
+        make_json_api_request :post, url, private_generate_resource("batches", { "events" => events })
       end
 
       # Public: Fetch all custom event actions.
@@ -41,7 +41,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#events
       def event_actions(options = {})
-        make_v2_request :get, "v2/#{account_id}/event_actions", options
+        make_json_api_request :get, "v2/#{account_id}/event_actions", options
       end
     end
   end

--- a/lib/drip/client/events.rb
+++ b/lib/drip/client/events.rb
@@ -14,7 +14,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#record_event
       def track_event(email, action, properties = {}, options = {})
         data = options.merge({ "email" => email, "action" => action, "properties" => properties })
-        post "v2/#{account_id}/events", private_generate_resource("events", data)
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/events"), private_generate_resource("events", data))
       end
 
       # Public: Track a collection of events all at once.
@@ -28,7 +28,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#event_batches
       def track_events(events)
         url = "v2/#{account_id}/events/batches"
-        post url, private_generate_resource("batches", { "events" => events })
+        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource("batches", { "events" => events }))
       end
 
       # Public: Fetch all custom event actions.
@@ -41,7 +41,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#events
       def event_actions(options = {})
-        get "v2/#{account_id}/event_actions", options
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/event_actions"), options)
       end
     end
   end

--- a/lib/drip/client/events.rb
+++ b/lib/drip/client/events.rb
@@ -14,7 +14,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#record_event
       def track_event(email, action, properties = {}, options = {})
         data = options.merge({ "email" => email, "action" => action, "properties" => properties })
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/events"), private_generate_resource("events", data))
+        make_v2_request :post, "v2/#{account_id}/events", private_generate_resource("events", data)
       end
 
       # Public: Track a collection of events all at once.
@@ -28,7 +28,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#event_batches
       def track_events(events)
         url = "v2/#{account_id}/events/batches"
-        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource("batches", { "events" => events }))
+        make_v2_request :post, url, private_generate_resource("batches", { "events" => events })
       end
 
       # Public: Fetch all custom event actions.
@@ -41,7 +41,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#events
       def event_actions(options = {})
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/event_actions"), options)
+        make_v2_request :get, "v2/#{account_id}/event_actions", options
       end
     end
   end

--- a/lib/drip/client/forms.rb
+++ b/lib/drip/client/forms.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#forms
       def forms
-        get "v2/#{account_id}/forms"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/forms"))
       end
 
       # Public: Fetch a form.
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#forms
       def form(id)
-        get "v2/#{account_id}/forms/#{id}"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/forms/#{id}"))
       end
     end
   end

--- a/lib/drip/client/forms.rb
+++ b/lib/drip/client/forms.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#forms
       def forms
-        make_v2_request :get, "v2/#{account_id}/forms"
+        make_json_api_request :get, "v2/#{account_id}/forms"
       end
 
       # Public: Fetch a form.
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#forms
       def form(id)
-        make_v2_request :get, "v2/#{account_id}/forms/#{id}"
+        make_json_api_request :get, "v2/#{account_id}/forms/#{id}"
       end
     end
   end

--- a/lib/drip/client/forms.rb
+++ b/lib/drip/client/forms.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#forms
       def forms
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/forms"))
+        make_v2_request :get, "v2/#{account_id}/forms"
       end
 
       # Public: Fetch a form.
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#forms
       def form(id)
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/forms/#{id}"))
+        make_v2_request :get, "v2/#{account_id}/forms/#{id}"
       end
     end
   end

--- a/lib/drip/client/http_client.rb
+++ b/lib/drip/client/http_client.rb
@@ -1,0 +1,59 @@
+module Drip
+  class Client
+    class HTTPClient
+      def initialize(config)
+        @config = config
+      end
+
+      def make_request(drip_request, redirected_url: nil, step: 0)
+        raise TooManyRedirectsError, 'too many HTTP redirects' if step >= REDIRECT_LIMIT
+
+        uri = redirected_url || drip_request.url.tap do |orig_url|
+          next if drip_request.http_verb != :get
+
+          orig_url.query = URI.encode_www_form(drip_request.options)
+        end
+
+        response = Net::HTTP.start(uri.host, uri.port, connection_options(uri.scheme)) do |http|
+          request = drip_request.verb_klass.new uri
+          request.body = drip_request.body
+
+          add_standard_headers(request)
+          request['Content-Type'] = drip_request.content_type
+
+          http.request request
+        end
+
+        return make_request(drip_request, redirected_url: URI(response["Location"]), step: step + 1) if response.is_a?(Net::HTTPRedirection)
+
+        response
+      end
+
+      def add_standard_headers(request)
+        request['User-Agent'] = "Drip Ruby v#{Drip::VERSION}"
+        request['Accept'] = "*/*"
+
+        if @config.access_token
+          request['Authorization'] = "Bearer #{@config.access_token}"
+        else
+          request.basic_auth @config.api_key, ""
+        end
+
+        request
+      end
+
+      def connection_options(uri_scheme)
+        options = { use_ssl: uri_scheme == "https" }
+
+        if @config.http_open_timeout
+          options[:open_timeout] = @config.http_open_timeout
+          options[:ssl_timeout] = @config.http_open_timeout
+        end
+
+        options[:read_timeout] = @config.http_timeout if @config.http_timeout
+
+        options
+      end
+    end
+  end
+end

--- a/lib/drip/client/http_client.rb
+++ b/lib/drip/client/http_client.rb
@@ -29,6 +29,8 @@ module Drip
         response
       end
 
+    private
+
       def add_standard_headers(request)
         request['User-Agent'] = "Drip Ruby v#{Drip::VERSION}"
         request['Accept'] = "*/*"

--- a/lib/drip/client/http_client.rb
+++ b/lib/drip/client/http_client.rb
@@ -1,6 +1,9 @@
 module Drip
   class Client
     class HTTPClient
+      REDIRECT_LIMIT = 10
+      private_constant :REDIRECT_LIMIT
+
       def initialize(config)
         @config = config
       end

--- a/lib/drip/client/orders.rb
+++ b/lib/drip/client/orders.rb
@@ -11,7 +11,7 @@ module Drip
       # See https://developer.drip.com/#orders
       def create_or_update_order(email, options = {})
         data = options.merge(email: email)
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/orders"), private_generate_resource("orders", data))
+        make_v2_request :post, "v2/#{account_id}/orders", private_generate_resource("orders", data)
       end
 
       # Public: Create or update a batch of orders.
@@ -21,7 +21,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-batch-of-orders
       def create_or_update_orders(orders)
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/orders/batches"), private_generate_resource("batches", { "orders" => orders }))
+        make_v2_request :post, "v2/#{account_id}/orders/batches", private_generate_resource("batches", { "orders" => orders })
       end
 
       # Public: Create or update a refund.
@@ -38,7 +38,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-refund
       def create_or_update_refund(options)
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/refunds"), private_generate_resource("refunds", options))
+        make_v2_request :post, "v2/#{account_id}/refunds", private_generate_resource("refunds", options)
       end
     end
   end

--- a/lib/drip/client/orders.rb
+++ b/lib/drip/client/orders.rb
@@ -11,7 +11,7 @@ module Drip
       # See https://developer.drip.com/#orders
       def create_or_update_order(email, options = {})
         data = options.merge(email: email)
-        post "v2/#{account_id}/orders", private_generate_resource("orders", data)
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/orders"), private_generate_resource("orders", data))
       end
 
       # Public: Create or update a batch of orders.
@@ -21,7 +21,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-batch-of-orders
       def create_or_update_orders(orders)
-        post "v2/#{account_id}/orders/batches", private_generate_resource("batches", { "orders" => orders })
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/orders/batches"), private_generate_resource("batches", { "orders" => orders }))
       end
 
       # Public: Create or update a refund.
@@ -38,7 +38,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-refund
       def create_or_update_refund(options)
-        post "v2/#{account_id}/refunds", private_generate_resource("refunds", options)
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/refunds"), private_generate_resource("refunds", options))
       end
     end
   end

--- a/lib/drip/client/orders.rb
+++ b/lib/drip/client/orders.rb
@@ -11,7 +11,7 @@ module Drip
       # See https://developer.drip.com/#orders
       def create_or_update_order(email, options = {})
         data = options.merge(email: email)
-        make_v2_request :post, "v2/#{account_id}/orders", private_generate_resource("orders", data)
+        make_json_api_request :post, "v2/#{account_id}/orders", private_generate_resource("orders", data)
       end
 
       # Public: Create or update a batch of orders.
@@ -21,7 +21,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-batch-of-orders
       def create_or_update_orders(orders)
-        make_v2_request :post, "v2/#{account_id}/orders/batches", private_generate_resource("batches", { "orders" => orders })
+        make_json_api_request :post, "v2/#{account_id}/orders/batches", private_generate_resource("batches", { "orders" => orders })
       end
 
       # Public: Create or update a refund.
@@ -38,7 +38,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-refund
       def create_or_update_refund(options)
-        make_v2_request :post, "v2/#{account_id}/refunds", private_generate_resource("refunds", options)
+        make_json_api_request :post, "v2/#{account_id}/refunds", private_generate_resource("refunds", options)
       end
     end
   end

--- a/lib/drip/client/subscribers.rb
+++ b/lib/drip/client/subscribers.rb
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#list_subscribers
       def subscribers(options = {})
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/subscribers"), options)
+        make_v2_request :get, "v2/#{account_id}/subscribers", options
       end
 
       # Public: Fetch a subscriber.
@@ -26,7 +26,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#fetch_subscriber
       def subscriber(id_or_email)
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"))
+        make_v2_request :get, "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
       end
 
       # Public: Create or update a subscriber.
@@ -51,7 +51,7 @@ module Drip
         data[:email] = args[0] if args[0].is_a? String
         data.merge!(args.last) if args.last.is_a? Hash
         raise ArgumentError, 'email: or id: parameter required' if !data.key?(:email) && !data.key?(:id)
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/subscribers"), private_generate_resource("subscribers", data))
+        make_v2_request :post, "v2/#{account_id}/subscribers", private_generate_resource("subscribers", data)
       end
 
       # Public: Create or update a collection of subscribers.
@@ -71,7 +71,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def create_or_update_subscribers(subscribers)
         url = "v2/#{account_id}/subscribers/batches"
-        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource("batches", { "subscribers" => subscribers }))
+        make_v2_request :post, url, private_generate_resource("batches", { "subscribers" => subscribers })
       end
 
       # Public: Unsubscribe a collection of subscribers.
@@ -83,7 +83,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def unsubscribe_subscribers(subscribers)
         url = "v2/#{account_id}/unsubscribes/batches"
-        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource("batches", { "subscribers" => subscribers }))
+        make_v2_request :post, url, private_generate_resource("batches", { "subscribers" => subscribers })
       end
 
       # Public: Unsubscribe a subscriber globally or from a specific campaign.
@@ -98,7 +98,7 @@ module Drip
       def unsubscribe(id_or_email, options = {})
         url = "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/remove"
         url += options[:campaign_id] ? "?campaign_id=#{options[:campaign_id]}" : ""
-        make_request Drip::Request.new(:post, make_uri(url))
+        make_v2_request :post, url
       end
 
       # Public: Subscribe to a campaign.
@@ -127,7 +127,7 @@ module Drip
       def subscribe(email, campaign_id, options = {})
         data = options.merge("email" => email)
         url = "v2/#{account_id}/campaigns/#{campaign_id}/subscribers"
-        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource("subscribers", data))
+        make_v2_request :post, url, private_generate_resource("subscribers", data)
       end
 
       # Public: Delete a subscriber.
@@ -137,7 +137,7 @@ module Drip
       # Returns No Content.
       # See https://www.getdrip.com/docs/rest-api#fdelete_subscriber
       def delete_subscriber(id_or_email)
-        make_request Drip::Request.new(:delete, make_uri("v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"))
+        make_v2_request :delete, "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
       end
 
       # Public: Unsubscribe a subscriber from all mailings.
@@ -147,7 +147,7 @@ module Drip
       # Returns No Content.
       # See https://www.getdrip.com/docs/rest-api#fdelete_subscriber
       def unsubscribe_from_all(id_or_email)
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/unsubscribe_all"))
+        make_v2_request :post, "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/unsubscribe_all"
       end
     end
   end

--- a/lib/drip/client/subscribers.rb
+++ b/lib/drip/client/subscribers.rb
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#list_subscribers
       def subscribers(options = {})
-        make_v2_request :get, "v2/#{account_id}/subscribers", options
+        make_json_api_request :get, "v2/#{account_id}/subscribers", options
       end
 
       # Public: Fetch a subscriber.
@@ -26,7 +26,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#fetch_subscriber
       def subscriber(id_or_email)
-        make_v2_request :get, "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
+        make_json_api_request :get, "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
       end
 
       # Public: Create or update a subscriber.
@@ -51,7 +51,7 @@ module Drip
         data[:email] = args[0] if args[0].is_a? String
         data.merge!(args.last) if args.last.is_a? Hash
         raise ArgumentError, 'email: or id: parameter required' if !data.key?(:email) && !data.key?(:id)
-        make_v2_request :post, "v2/#{account_id}/subscribers", private_generate_resource("subscribers", data)
+        make_json_api_request :post, "v2/#{account_id}/subscribers", private_generate_resource("subscribers", data)
       end
 
       # Public: Create or update a collection of subscribers.
@@ -71,7 +71,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def create_or_update_subscribers(subscribers)
         url = "v2/#{account_id}/subscribers/batches"
-        make_v2_request :post, url, private_generate_resource("batches", { "subscribers" => subscribers })
+        make_json_api_request :post, url, private_generate_resource("batches", { "subscribers" => subscribers })
       end
 
       # Public: Unsubscribe a collection of subscribers.
@@ -83,7 +83,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def unsubscribe_subscribers(subscribers)
         url = "v2/#{account_id}/unsubscribes/batches"
-        make_v2_request :post, url, private_generate_resource("batches", { "subscribers" => subscribers })
+        make_json_api_request :post, url, private_generate_resource("batches", { "subscribers" => subscribers })
       end
 
       # Public: Unsubscribe a subscriber globally or from a specific campaign.
@@ -98,7 +98,7 @@ module Drip
       def unsubscribe(id_or_email, options = {})
         url = "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/remove"
         url += options[:campaign_id] ? "?campaign_id=#{options[:campaign_id]}" : ""
-        make_v2_request :post, url
+        make_json_api_request :post, url
       end
 
       # Public: Subscribe to a campaign.
@@ -127,7 +127,7 @@ module Drip
       def subscribe(email, campaign_id, options = {})
         data = options.merge("email" => email)
         url = "v2/#{account_id}/campaigns/#{campaign_id}/subscribers"
-        make_v2_request :post, url, private_generate_resource("subscribers", data)
+        make_json_api_request :post, url, private_generate_resource("subscribers", data)
       end
 
       # Public: Delete a subscriber.
@@ -137,7 +137,7 @@ module Drip
       # Returns No Content.
       # See https://www.getdrip.com/docs/rest-api#fdelete_subscriber
       def delete_subscriber(id_or_email)
-        make_v2_request :delete, "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
+        make_json_api_request :delete, "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
       end
 
       # Public: Unsubscribe a subscriber from all mailings.
@@ -147,7 +147,7 @@ module Drip
       # Returns No Content.
       # See https://www.getdrip.com/docs/rest-api#fdelete_subscriber
       def unsubscribe_from_all(id_or_email)
-        make_v2_request :post, "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/unsubscribe_all"
+        make_json_api_request :post, "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/unsubscribe_all"
       end
     end
   end

--- a/lib/drip/client/subscribers.rb
+++ b/lib/drip/client/subscribers.rb
@@ -16,7 +16,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#list_subscribers
       def subscribers(options = {})
-        get "v2/#{account_id}/subscribers", options
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/subscribers"), options)
       end
 
       # Public: Fetch a subscriber.
@@ -26,7 +26,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#fetch_subscriber
       def subscriber(id_or_email)
-        get "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"))
       end
 
       # Public: Create or update a subscriber.
@@ -51,7 +51,7 @@ module Drip
         data[:email] = args[0] if args[0].is_a? String
         data.merge!(args.last) if args.last.is_a? Hash
         raise ArgumentError, 'email: or id: parameter required' if !data.key?(:email) && !data.key?(:id)
-        post "v2/#{account_id}/subscribers", private_generate_resource("subscribers", data)
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/subscribers"), private_generate_resource("subscribers", data))
       end
 
       # Public: Create or update a collection of subscribers.
@@ -71,7 +71,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def create_or_update_subscribers(subscribers)
         url = "v2/#{account_id}/subscribers/batches"
-        post url, private_generate_resource("batches", { "subscribers" => subscribers })
+        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource("batches", { "subscribers" => subscribers }))
       end
 
       # Public: Unsubscribe a collection of subscribers.
@@ -83,7 +83,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def unsubscribe_subscribers(subscribers)
         url = "v2/#{account_id}/unsubscribes/batches"
-        post url, private_generate_resource("batches", { "subscribers" => subscribers })
+        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource("batches", { "subscribers" => subscribers }))
       end
 
       # Public: Unsubscribe a subscriber globally or from a specific campaign.
@@ -98,7 +98,7 @@ module Drip
       def unsubscribe(id_or_email, options = {})
         url = "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/remove"
         url += options[:campaign_id] ? "?campaign_id=#{options[:campaign_id]}" : ""
-        post url
+        make_request Drip::Request.new(:post, make_uri(url))
       end
 
       # Public: Subscribe to a campaign.
@@ -127,7 +127,7 @@ module Drip
       def subscribe(email, campaign_id, options = {})
         data = options.merge("email" => email)
         url = "v2/#{account_id}/campaigns/#{campaign_id}/subscribers"
-        post url, private_generate_resource("subscribers", data)
+        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource("subscribers", data))
       end
 
       # Public: Delete a subscriber.
@@ -137,7 +137,7 @@ module Drip
       # Returns No Content.
       # See https://www.getdrip.com/docs/rest-api#fdelete_subscriber
       def delete_subscriber(id_or_email)
-        delete "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"
+        make_request Drip::Request.new(:delete, make_uri("v2/#{account_id}/subscribers/#{CGI.escape id_or_email}"))
       end
 
       # Public: Unsubscribe a subscriber from all mailings.
@@ -147,7 +147,7 @@ module Drip
       # Returns No Content.
       # See https://www.getdrip.com/docs/rest-api#fdelete_subscriber
       def unsubscribe_from_all(id_or_email)
-        post "v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/unsubscribe_all"
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/subscribers/#{CGI.escape id_or_email}/unsubscribe_all"))
       end
     end
   end

--- a/lib/drip/client/tags.rb
+++ b/lib/drip/client/tags.rb
@@ -8,7 +8,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#tags
       def tags
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/tags"))
+        make_v2_request :get, "v2/#{account_id}/tags"
       end
 
       # Public: Apply a tag to a subscriber.
@@ -20,7 +20,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#apply_tag
       def apply_tag(email, tag)
         data = { "email" => email, "tag" => tag }
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/tags"), private_generate_resource("tags", data))
+        make_v2_request :post, "v2/#{account_id}/tags", private_generate_resource("tags", data)
       end
 
       # Public: Remove a tag from a subscriber.
@@ -31,7 +31,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#remove_tag
       def remove_tag(email, tag)
-        make_request Drip::Request.new(:delete, make_uri("v2/#{account_id}/subscribers/#{CGI.escape email}/tags/#{CGI.escape tag}"))
+        make_v2_request :delete, "v2/#{account_id}/subscribers/#{CGI.escape email}/tags/#{CGI.escape tag}"
       end
     end
   end

--- a/lib/drip/client/tags.rb
+++ b/lib/drip/client/tags.rb
@@ -8,7 +8,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#tags
       def tags
-        get "v2/#{account_id}/tags"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/tags"))
       end
 
       # Public: Apply a tag to a subscriber.
@@ -20,7 +20,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#apply_tag
       def apply_tag(email, tag)
         data = { "email" => email, "tag" => tag }
-        post "v2/#{account_id}/tags", private_generate_resource("tags", data)
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/tags"), private_generate_resource("tags", data))
       end
 
       # Public: Remove a tag from a subscriber.
@@ -31,7 +31,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#remove_tag
       def remove_tag(email, tag)
-        delete "v2/#{account_id}/subscribers/#{CGI.escape email}/tags/#{CGI.escape tag}"
+        make_request Drip::Request.new(:delete, make_uri("v2/#{account_id}/subscribers/#{CGI.escape email}/tags/#{CGI.escape tag}"))
       end
     end
   end

--- a/lib/drip/client/tags.rb
+++ b/lib/drip/client/tags.rb
@@ -8,7 +8,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#tags
       def tags
-        make_v2_request :get, "v2/#{account_id}/tags"
+        make_json_api_request :get, "v2/#{account_id}/tags"
       end
 
       # Public: Apply a tag to a subscriber.
@@ -20,7 +20,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#apply_tag
       def apply_tag(email, tag)
         data = { "email" => email, "tag" => tag }
-        make_v2_request :post, "v2/#{account_id}/tags", private_generate_resource("tags", data)
+        make_json_api_request :post, "v2/#{account_id}/tags", private_generate_resource("tags", data)
       end
 
       # Public: Remove a tag from a subscriber.
@@ -31,7 +31,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#remove_tag
       def remove_tag(email, tag)
-        make_v2_request :delete, "v2/#{account_id}/subscribers/#{CGI.escape email}/tags/#{CGI.escape tag}"
+        make_json_api_request :delete, "v2/#{account_id}/subscribers/#{CGI.escape email}/tags/#{CGI.escape tag}"
       end
     end
   end

--- a/lib/drip/client/webhooks.rb
+++ b/lib/drip/client/webhooks.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def webhooks
-        make_v2_request :get, "v2/#{account_id}/webhooks"
+        make_json_api_request :get, "v2/#{account_id}/webhooks"
       end
 
       # Public: Fetch a webhook
@@ -15,7 +15,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def webhook(id)
-        make_v2_request :get, "v2/#{account_id}/webhooks/#{id}"
+        make_json_api_request :get, "v2/#{account_id}/webhooks/#{id}"
       end
 
       # Public: Create a webhook.
@@ -36,7 +36,7 @@ module Drip
         include_received_email = include_received_email ? true : false
         url = "v2/#{account_id}/webhooks"
 
-        make_v2_request :post, url, private_generate_resource(
+        make_json_api_request :post, url, private_generate_resource(
           "webhooks",
           {
             "post_url" => post_url,
@@ -52,7 +52,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def delete_webhook(id)
-        make_v2_request :delete, "v2/#{account_id}/webhooks/#{id}"
+        make_json_api_request :delete, "v2/#{account_id}/webhooks/#{id}"
       end
     end
   end

--- a/lib/drip/client/webhooks.rb
+++ b/lib/drip/client/webhooks.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def webhooks
-        get "v2/#{account_id}/webhooks"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/webhooks"))
       end
 
       # Public: Fetch a webhook
@@ -15,7 +15,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def webhook(id)
-        get "v2/#{account_id}/webhooks/#{id}"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/webhooks/#{id}"))
       end
 
       # Public: Create a webhook.
@@ -36,14 +36,14 @@ module Drip
         include_received_email = include_received_email ? true : false
         url = "v2/#{account_id}/webhooks"
 
-        post url, private_generate_resource(
+        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource(
           "webhooks",
           {
             "post_url" => post_url,
             "include_received_email" => include_received_email,
             "events" => events
           }
-        )
+        ))
       end
 
       # Public: List all webhooks.
@@ -52,7 +52,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def delete_webhook(id)
-        delete "v2/#{account_id}/webhooks/#{id}"
+        make_request Drip::Request.new(:delete, make_uri("v2/#{account_id}/webhooks/#{id}"))
       end
     end
   end

--- a/lib/drip/client/webhooks.rb
+++ b/lib/drip/client/webhooks.rb
@@ -6,7 +6,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def webhooks
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/webhooks"))
+        make_v2_request :get, "v2/#{account_id}/webhooks"
       end
 
       # Public: Fetch a webhook
@@ -15,7 +15,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def webhook(id)
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/webhooks/#{id}"))
+        make_v2_request :get, "v2/#{account_id}/webhooks/#{id}"
       end
 
       # Public: Create a webhook.
@@ -36,14 +36,14 @@ module Drip
         include_received_email = include_received_email ? true : false
         url = "v2/#{account_id}/webhooks"
 
-        make_request Drip::Request.new(:post, make_uri(url), private_generate_resource(
+        make_v2_request :post, url, private_generate_resource(
           "webhooks",
           {
             "post_url" => post_url,
             "include_received_email" => include_received_email,
             "events" => events
           }
-        ))
+        )
       end
 
       # Public: List all webhooks.
@@ -52,7 +52,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#webhooks
       def delete_webhook(id)
-        make_request Drip::Request.new(:delete, make_uri("v2/#{account_id}/webhooks/#{id}"))
+        make_v2_request :delete, "v2/#{account_id}/webhooks/#{id}"
       end
     end
   end

--- a/lib/drip/client/workflow_triggers.rb
+++ b/lib/drip/client/workflow_triggers.rb
@@ -7,7 +7,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflow_triggers
       def workflow_triggers(id)
-        get "v2/#{account_id}/workflows/#{id}/triggers"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/workflows/#{id}/triggers"))
       end
 
       # Public: Create a workflow trigger.
@@ -22,7 +22,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def create_workflow_trigger(id, options = {})
-        post "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/workflows/#{id}/triggers"), private_generate_resource("triggers", options))
       end
 
       # Public: Update a workflow trigger.
@@ -37,7 +37,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def update_workflow_trigger(id, options = {})
-        put "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
+        make_request Drip::Request.new(:put, make_uri("v2/#{account_id}/workflows/#{id}/triggers"), private_generate_resource("triggers", options))
       end
     end
   end

--- a/lib/drip/client/workflow_triggers.rb
+++ b/lib/drip/client/workflow_triggers.rb
@@ -7,7 +7,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflow_triggers
       def workflow_triggers(id)
-        make_v2_request :get, "v2/#{account_id}/workflows/#{id}/triggers"
+        make_json_api_request :get, "v2/#{account_id}/workflows/#{id}/triggers"
       end
 
       # Public: Create a workflow trigger.
@@ -22,7 +22,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def create_workflow_trigger(id, options = {})
-        make_v2_request :post, "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
+        make_json_api_request :post, "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
       end
 
       # Public: Update a workflow trigger.
@@ -37,7 +37,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def update_workflow_trigger(id, options = {})
-        make_v2_request :put, "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
+        make_json_api_request :put, "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
       end
     end
   end

--- a/lib/drip/client/workflow_triggers.rb
+++ b/lib/drip/client/workflow_triggers.rb
@@ -7,7 +7,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflow_triggers
       def workflow_triggers(id)
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/workflows/#{id}/triggers"))
+        make_v2_request :get, "v2/#{account_id}/workflows/#{id}/triggers"
       end
 
       # Public: Create a workflow trigger.
@@ -22,7 +22,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def create_workflow_trigger(id, options = {})
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/workflows/#{id}/triggers"), private_generate_resource("triggers", options))
+        make_v2_request :post, "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
       end
 
       # Public: Update a workflow trigger.
@@ -37,7 +37,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def update_workflow_trigger(id, options = {})
-        make_request Drip::Request.new(:put, make_uri("v2/#{account_id}/workflows/#{id}/triggers"), private_generate_resource("triggers", options))
+        make_v2_request :put, "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
       end
     end
   end

--- a/lib/drip/client/workflows.rb
+++ b/lib/drip/client/workflows.rb
@@ -12,7 +12,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def workflows(options = {})
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/workflows"), options)
+        make_v2_request :get, "v2/#{account_id}/workflows", options
       end
 
       # Public: Fetch a workflow.
@@ -21,7 +21,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def workflow(id)
-        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/workflows/#{id}"))
+        make_v2_request :get, "v2/#{account_id}/workflows/#{id}"
       end
 
       # Public: Activate a workflow.
@@ -30,7 +30,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def activate_workflow(id)
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/workflows/#{id}/activate"))
+        make_v2_request :post, "v2/#{account_id}/workflows/#{id}/activate"
       end
 
       # Public: Pause a workflow.
@@ -39,7 +39,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def pause_workflow(id)
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/workflows/#{id}/pause"))
+        make_v2_request :post, "v2/#{account_id}/workflows/#{id}/pause"
       end
 
       # Public: Start someone on a workflow.
@@ -63,7 +63,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def start_subscriber_workflow(id, options = {})
-        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/workflows/#{id}/subscribers"), private_generate_resource("subscribers", options))
+        make_v2_request :post, "v2/#{account_id}/workflows/#{id}/subscribers", private_generate_resource("subscribers", options)
       end
 
       # Public: Remove someone from a workflow.
@@ -73,7 +73,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def remove_subscriber_workflow(workflow_id, id_or_email)
-        make_request Drip::Request.new(:delete, make_uri("v2/#{account_id}/workflows/#{workflow_id}/subscribers/#{CGI.escape id_or_email}"))
+        make_v2_request :delete, "v2/#{account_id}/workflows/#{workflow_id}/subscribers/#{CGI.escape id_or_email}"
       end
     end
   end

--- a/lib/drip/client/workflows.rb
+++ b/lib/drip/client/workflows.rb
@@ -12,7 +12,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def workflows(options = {})
-        make_v2_request :get, "v2/#{account_id}/workflows", options
+        make_json_api_request :get, "v2/#{account_id}/workflows", options
       end
 
       # Public: Fetch a workflow.
@@ -21,7 +21,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def workflow(id)
-        make_v2_request :get, "v2/#{account_id}/workflows/#{id}"
+        make_json_api_request :get, "v2/#{account_id}/workflows/#{id}"
       end
 
       # Public: Activate a workflow.
@@ -30,7 +30,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def activate_workflow(id)
-        make_v2_request :post, "v2/#{account_id}/workflows/#{id}/activate"
+        make_json_api_request :post, "v2/#{account_id}/workflows/#{id}/activate"
       end
 
       # Public: Pause a workflow.
@@ -39,7 +39,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def pause_workflow(id)
-        make_v2_request :post, "v2/#{account_id}/workflows/#{id}/pause"
+        make_json_api_request :post, "v2/#{account_id}/workflows/#{id}/pause"
       end
 
       # Public: Start someone on a workflow.
@@ -63,7 +63,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def start_subscriber_workflow(id, options = {})
-        make_v2_request :post, "v2/#{account_id}/workflows/#{id}/subscribers", private_generate_resource("subscribers", options)
+        make_json_api_request :post, "v2/#{account_id}/workflows/#{id}/subscribers", private_generate_resource("subscribers", options)
       end
 
       # Public: Remove someone from a workflow.
@@ -73,7 +73,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def remove_subscriber_workflow(workflow_id, id_or_email)
-        make_v2_request :delete, "v2/#{account_id}/workflows/#{workflow_id}/subscribers/#{CGI.escape id_or_email}"
+        make_json_api_request :delete, "v2/#{account_id}/workflows/#{workflow_id}/subscribers/#{CGI.escape id_or_email}"
       end
     end
   end

--- a/lib/drip/client/workflows.rb
+++ b/lib/drip/client/workflows.rb
@@ -12,7 +12,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def workflows(options = {})
-        get "v2/#{account_id}/workflows", options
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/workflows"), options)
       end
 
       # Public: Fetch a workflow.
@@ -21,7 +21,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def workflow(id)
-        get "v2/#{account_id}/workflows/#{id}"
+        make_request Drip::Request.new(:get, make_uri("v2/#{account_id}/workflows/#{id}"))
       end
 
       # Public: Activate a workflow.
@@ -30,7 +30,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def activate_workflow(id)
-        post "v2/#{account_id}/workflows/#{id}/activate"
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/workflows/#{id}/activate"))
       end
 
       # Public: Pause a workflow.
@@ -39,7 +39,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def pause_workflow(id)
-        post "v2/#{account_id}/workflows/#{id}/pause"
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/workflows/#{id}/pause"))
       end
 
       # Public: Start someone on a workflow.
@@ -63,7 +63,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def start_subscriber_workflow(id, options = {})
-        post "v2/#{account_id}/workflows/#{id}/subscribers", private_generate_resource("subscribers", options)
+        make_request Drip::Request.new(:post, make_uri("v2/#{account_id}/workflows/#{id}/subscribers"), private_generate_resource("subscribers", options))
       end
 
       # Public: Remove someone from a workflow.
@@ -73,7 +73,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def remove_subscriber_workflow(workflow_id, id_or_email)
-        delete "v2/#{account_id}/workflows/#{workflow_id}/subscribers/#{CGI.escape id_or_email}"
+        make_request Drip::Request.new(:delete, make_uri("v2/#{account_id}/workflows/#{workflow_id}/subscribers/#{CGI.escape id_or_email}"))
       end
     end
   end

--- a/lib/drip/request.rb
+++ b/lib/drip/request.rb
@@ -1,0 +1,29 @@
+module Drip
+  class Request
+    attr_reader :http_verb, :url, :options, :content_type
+
+    VERB_CLASS_MAPPING = {
+      get: Net::HTTP::Get,
+      post: Net::HTTP::Post,
+      put: Net::HTTP::Put,
+      delete: Net::HTTP::Delete
+    }.freeze
+
+    def initialize(http_verb, url, options, content_type)
+      @http_verb = http_verb
+      @url = url
+      @options = options
+      @content_type = content_type
+    end
+
+    def verb_klass
+      VERB_CLASS_MAPPING[http_verb]
+    end
+
+    def body
+      return if http_verb == :get
+
+      options.to_json
+    end
+  end
+end

--- a/lib/drip/request.rb
+++ b/lib/drip/request.rb
@@ -1,3 +1,5 @@
+require "net/http"
+
 module Drip
   class Request
     attr_reader :http_verb, :url, :options, :content_type

--- a/lib/drip/request.rb
+++ b/lib/drip/request.rb
@@ -11,7 +11,7 @@ module Drip
       delete: Net::HTTP::Delete
     }.freeze
 
-    def initialize(http_verb, url, options, content_type)
+    def initialize(http_verb, url, options = {}, content_type = nil)
       @http_verb = http_verb
       @url = url
       @options = options

--- a/test/drip/client/http_client_test.rb
+++ b/test/drip/client/http_client_test.rb
@@ -68,7 +68,7 @@ class Drip::Client::HTTPClientTest < Drip::TestCase
 
   context "given a get request" do
     setup do
-      @config = Drip::Client::Configuration.new
+      @config = Drip::Client::Configuration.new(http_open_timeout: 20)
       @client = Drip::Client::HTTPClient.new(@config)
       @response = mock
       @response.stubs(:code).returns('200')

--- a/test/drip/client/http_client_test.rb
+++ b/test/drip/client/http_client_test.rb
@@ -1,0 +1,96 @@
+require File.dirname(__FILE__) + '/../../test_helper.rb'
+require "drip/client/configuration"
+require "drip/client/http_client"
+require "drip/request"
+
+class Drip::Client::HTTPClientTest < Drip::TestCase
+  context "given a personal api key" do
+    setup do
+      @key = "aaaa"
+      @config = Drip::Client::Configuration.new(api_key: @key)
+      @client = Drip::Client::HTTPClient.new(@config)
+    end
+
+    should "use Basic authentication" do
+      stub_request(:get, "https://api.getdrip.com/v2/testpath").
+        to_return(status: 200, body: "", headers: {})
+
+      @client.make_request(Drip::Request.new(:get, URI("https://api.getdrip.com/v2/testpath")))
+
+      header = "Basic #{Base64.encode64(@key + ':')}".strip
+      assert_requested :get, "https://api.getdrip.com/v2/testpath", headers: { 'Authorization' => header }
+    end
+  end
+
+  context "given a OAuth access token" do
+    setup do
+      @key = "aaaa"
+      @config = Drip::Client::Configuration.new(access_token: @key)
+      @client = Drip::Client::HTTPClient.new(@config)
+    end
+
+    should "use Bearer token authentication" do
+      stub_request(:get, "https://api.getdrip.com/v2/testpath").
+        to_return(status: 200, body: "", headers: {})
+      @client.make_request(Drip::Request.new(:get, URI("https://api.getdrip.com/v2/testpath")))
+      header = "Bearer #{@key}"
+      assert_requested :get, "https://api.getdrip.com/v2/testpath", headers: { 'Authorization' => header }
+    end
+  end
+
+  context "given a redirecting url" do
+    setup do
+      @config = Drip::Client::Configuration.new
+      @client = Drip::Client::HTTPClient.new(@config)
+    end
+
+    should "follow redirect" do
+      stub_request(:get, "https://api.getdrip.com/v2/testpath").
+        to_return(status: 301, body: "", headers: { "Location" => "https://api.example.com/mytestpath" })
+      stub_request(:get, "https://api.example.com/mytestpath").
+        to_return(status: 200, body: "{}")
+      response = @client.make_request(Drip::Request.new(:get, URI("https://api.getdrip.com/v2/testpath")))
+      assert_requested :get, "https://api.getdrip.com/v2/testpath"
+      assert_requested :get, "https://api.example.com/mytestpath"
+      assert_equal("{}", response.body)
+    end
+
+    should "not follow too many redirects" do
+      stub_request(:get, "https://api.getdrip.com/v2/accounts").
+        to_return(status: 301, body: "", headers: { "Location" => "https://api.example.com/mytestpath" })
+      stub_request(:get, "https://api.example.com/mytestpath").
+        to_return(status: 302, body: "", headers: { "Location" => "https://api.getdrip.com/v2/accounts" })
+      assert_raises(Drip::TooManyRedirectsError) { @client.make_request(Drip::Request.new(:get, URI("https://api.getdrip.com/v2/accounts"))) }
+      assert_requested :get, "https://api.getdrip.com/v2/accounts", times: 5
+      assert_requested :get, "https://api.example.com/mytestpath", times: 5
+    end
+  end
+
+  context "given a get request" do
+    setup do
+      @config = Drip::Client::Configuration.new
+      @client = Drip::Client::HTTPClient.new(@config)
+      @response = mock
+      @response.stubs(:code).returns('200')
+      @response.stubs(:body).returns('{}')
+
+      @http = mock
+      @http.expects(:request).returns(@response)
+
+      @request = mock
+      @request.stubs(:[]=)
+      @request.stubs(:basic_auth)
+    end
+
+    should "encode query and not set body" do
+      Net::HTTP::Get.expects(:new).returns(@request)
+      Net::HTTP.expects(:start).yields(@http).returns(@response)
+
+      @request.expects(:body=).with(nil)
+      URI.expects(:encode_www_form).once
+
+      response = @client.make_request(Drip::Request.new(:get, URI("https://api.getdrip.com/v2/testpath")))
+      assert_equal("{}", response.body)
+    end
+  end
+end

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -50,6 +50,13 @@ class Drip::ClientTest < Drip::TestCase
       assert_equal 20, client.http_open_timeout
       assert_equal 25, client.http_timeout
     end
+
+    should "accept options after initialization" do
+      # Deprecated
+      client = Drip::Client.new
+      assert_output(nil, /^\[DEPRECATED\] Setting configuration/) { client.account_id = "12345" }
+      assert_equal "12345", client.account_id
+    end
   end
 
   context "given a basic request" do
@@ -93,6 +100,39 @@ class Drip::ClientTest < Drip::TestCase
       @client.subscriber("blah")
 
       assert_requested :get, "https://api.example.com/v9001/v2/subscribers/blah"
+    end
+  end
+
+  context "#generate_resource" do
+    # Deprecated
+    should "return a resource and note deprecation" do
+      client = Drip::Client.new
+      resource = nil
+      assert_output(nil, /^\[DEPRECATED\] Drip\:\:Client\#generate_resource is deprecated/) { resource = client.generate_resource("hello", {}) }
+      assert_equal({ "hello" => [{}] }, resource)
+    end
+  end
+
+  context "#content_type" do
+    # Deprecated
+    should "return default content type and print warning" do
+      client = Drip::Client.new
+      content_type = nil
+      assert_output(nil, /^\[DEPRECATED\] Drip\:\:Client\#content_type is deprecated/) { content_type = client.content_type }
+      assert_equal "application/vnd.api+json", content_type
+    end
+  end
+
+  context "#get et all" do
+    # Deprecated
+    should "delegate with v2 and print deprecation warning" do
+      stub_request(:get, "https://api.getdrip.com/v2/testpath").
+        to_return(status: 200, body: "{}")
+
+      client = Drip::Client.new
+      response = nil
+      assert_output(nil, /^\[DEPRECATED\] Drip\:\:Client\#get please use the API endpoint specific methods/) { response = client.get("testpath") }
+      assert_equal({}, response.body)
     end
   end
 end

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -52,40 +52,6 @@ class Drip::ClientTest < Drip::TestCase
     end
   end
 
-  context "#generate_resource" do
-    # Deprecated
-    setup do
-      @key = "subscribers"
-      @data = { "email" => "foo" }
-      @client = Drip::Client.new
-    end
-
-    should "return a JSON API payload" do
-      assert_output(nil, /^\[DEPRECATED\] Drip\:\:Client\#generate_resource is deprecated/) do
-        assert_equal({ @key => [@data] }, @client.generate_resource(@key, @data))
-      end
-    end
-  end
-
-  context "given a personal api key" do
-    setup do
-      @key = "aaaa"
-      @client = Drip::Client.new do |config|
-        config.api_key = @key
-      end
-    end
-
-    should "use Basic authentication" do
-      stub_request(:get, "https://api.getdrip.com/v2/testpath").
-        to_return(status: 200, body: "", headers: {})
-
-      @client.get("testpath")
-
-      header = "Basic #{Base64.encode64(@key + ':')}".strip
-      assert_requested :get, "https://api.getdrip.com/v2/testpath", headers: { 'Authorization' => header }
-    end
-  end
-
   context "given a basic request" do
     setup do
       @client = Drip::Client.new do |config|
@@ -122,84 +88,11 @@ class Drip::ClientTest < Drip::TestCase
     end
 
     should "connect to alternate prefix with prepended v2" do
-      stub_request(:get, "https://api.example.com/v9001/v2/testpath").
+      stub_request(:get, "https://api.example.com/v9001/v2/subscribers/blah").
         to_return(status: 200, body: "", headers: {})
-      assert_output(nil, /^\[DEPRECATED\] Drip::Client#get please use the API endpoint specific methods/) do
-        @client.get("testpath")
-      end
+      @client.subscriber("blah")
 
-      assert_requested :get, "https://api.example.com/v9001/v2/testpath"
-    end
-  end
-
-  context "given a OAuth access token" do
-    setup do
-      @key = "aaaa"
-      @client = Drip::Client.new do |config|
-        config.access_token = @key
-      end
-    end
-
-    should "use Bearer token authentication" do
-      stub_request(:get, "https://api.getdrip.com/v2/testpath").
-        to_return(status: 200, body: "", headers: {})
-      @client.get("testpath")
-      header = "Bearer #{@key}"
-      assert_requested :get, "https://api.getdrip.com/v2/testpath", headers: { 'Authorization' => header }
-    end
-  end
-
-  context "given a redirecting url" do
-    setup do
-      @client = Drip::Client.new
-    end
-
-    should "follow redirect" do
-      stub_request(:get, "https://api.getdrip.com/v2/testpath").
-        to_return(status: 301, body: "", headers: { "Location" => "https://api.example.com/mytestpath" })
-      stub_request(:get, "https://api.example.com/mytestpath").
-        to_return(status: 200, body: "{}")
-      response = @client.get("testpath")
-      assert_requested :get, "https://api.getdrip.com/v2/testpath"
-      assert_requested :get, "https://api.example.com/mytestpath"
-      assert_equal({}, response.body)
-    end
-
-    should "not follow too many redirects" do
-      stub_request(:get, "https://api.getdrip.com/v2/accounts").
-        to_return(status: 301, body: "", headers: { "Location" => "https://api.example.com/mytestpath" })
-      stub_request(:get, "https://api.example.com/mytestpath").
-        to_return(status: 302, body: "", headers: { "Location" => "https://api.getdrip.com/v2/accounts" })
-      assert_raises(Drip::TooManyRedirectsError) { @client.accounts }
-      assert_requested :get, "https://api.getdrip.com/v2/accounts", times: 5
-      assert_requested :get, "https://api.example.com/mytestpath", times: 5
-    end
-  end
-
-  context "given a get request" do
-    setup do
-      @client = Drip::Client.new
-      @response = mock
-      @response.stubs(:code).returns('200')
-      @response.stubs(:body).returns('{}')
-
-      @http = mock
-      @http.expects(:request).returns(@response)
-
-      @request = mock
-      @request.stubs(:[]=)
-      @request.stubs(:basic_auth)
-    end
-
-    should "encode query and not set body" do
-      Net::HTTP::Get.expects(:new).returns(@request)
-      Net::HTTP.expects(:start).yields(@http).returns(@response)
-
-      @request.expects(:body=).with(nil)
-      URI.expects(:encode_www_form).once
-
-      response = @client.get("testpath")
-      assert_equal({}, response.body)
+      assert_requested :get, "https://api.example.com/v9001/v2/subscribers/blah"
     end
   end
 end

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -92,15 +92,16 @@ class Drip::ClientTest < Drip::TestCase
       @client = Drip::Client.new do |config|
         config.api_key = @key
         config.url_prefix = @url_prefix
+        config.account_id = "12345"
       end
     end
 
     should "connect to alternate prefix with prepended v2" do
-      stub_request(:get, "https://api.example.com/v9001/v2/subscribers/blah").
+      stub_request(:get, "https://api.example.com/v9001/v2/12345/subscribers/blah").
         to_return(status: 200, body: "", headers: {})
       @client.subscriber("blah")
 
-      assert_requested :get, "https://api.example.com/v9001/v2/subscribers/blah"
+      assert_requested :get, "https://api.example.com/v9001/v2/12345/subscribers/blah"
     end
   end
 

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -79,7 +79,7 @@ class Drip::ClientTest < Drip::TestCase
       stub_request(:get, "https://api.getdrip.com/v2/testpath").
         to_return(status: 200, body: "", headers: {})
 
-      @client.get("v2/testpath")
+      @client.get("testpath")
 
       header = "Basic #{Base64.encode64(@key + ':')}".strip
       assert_requested :get, "https://api.getdrip.com/v2/testpath", headers: { 'Authorization' => header }
@@ -124,7 +124,7 @@ class Drip::ClientTest < Drip::TestCase
     should "connect to alternate prefix with prepended v2" do
       stub_request(:get, "https://api.example.com/v9001/v2/testpath").
         to_return(status: 200, body: "", headers: {})
-      assert_output(nil, /\A\[DEPRECATED\] Automatically prepended path/) do
+      assert_output(nil, /^\[DEPRECATED\] Drip::Client#get please use the API endpoint specific methods/) do
         @client.get("testpath")
       end
 
@@ -143,7 +143,7 @@ class Drip::ClientTest < Drip::TestCase
     should "use Bearer token authentication" do
       stub_request(:get, "https://api.getdrip.com/v2/testpath").
         to_return(status: 200, body: "", headers: {})
-      @client.get("v2/testpath")
+      @client.get("testpath")
       header = "Bearer #{@key}"
       assert_requested :get, "https://api.getdrip.com/v2/testpath", headers: { 'Authorization' => header }
     end
@@ -159,19 +159,19 @@ class Drip::ClientTest < Drip::TestCase
         to_return(status: 301, body: "", headers: { "Location" => "https://api.example.com/mytestpath" })
       stub_request(:get, "https://api.example.com/mytestpath").
         to_return(status: 200, body: "{}")
-      response = @client.get("v2/testpath")
+      response = @client.get("testpath")
       assert_requested :get, "https://api.getdrip.com/v2/testpath"
       assert_requested :get, "https://api.example.com/mytestpath"
       assert_equal({}, response.body)
     end
 
     should "not follow too many redirects" do
-      stub_request(:get, "https://api.getdrip.com/v2/testpath").
+      stub_request(:get, "https://api.getdrip.com/v2/accounts").
         to_return(status: 301, body: "", headers: { "Location" => "https://api.example.com/mytestpath" })
       stub_request(:get, "https://api.example.com/mytestpath").
-        to_return(status: 302, body: "", headers: { "Location" => "https://api.getdrip.com/v2/testpath" })
-      assert_raises(Drip::TooManyRedirectsError) { @client.get("v2/testpath") }
-      assert_requested :get, "https://api.getdrip.com/v2/testpath", times: 5
+        to_return(status: 302, body: "", headers: { "Location" => "https://api.getdrip.com/v2/accounts" })
+      assert_raises(Drip::TooManyRedirectsError) { @client.accounts }
+      assert_requested :get, "https://api.getdrip.com/v2/accounts", times: 5
       assert_requested :get, "https://api.example.com/mytestpath", times: 5
     end
   end
@@ -195,10 +195,10 @@ class Drip::ClientTest < Drip::TestCase
       Net::HTTP::Get.expects(:new).returns(@request)
       Net::HTTP.expects(:start).yields(@http).returns(@response)
 
-      @request.expects(:body=).never
+      @request.expects(:body=).with(nil)
       URI.expects(:encode_www_form).once
 
-      response = @client.get("v2/testpath")
+      response = @client.get("testpath")
       assert_equal({}, response.body)
     end
   end

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -69,6 +69,7 @@ class Drip::ClientTest < Drip::TestCase
 
     should "return objects" do
       stub_request(:get, "https://api.getdrip.com/v2/12345/subscribers/jdoe%40example.com").
+        with(headers: { "Content-Type" => "application/vnd.api+json" }).
         to_return(status: 200, body: "{\"links\":{\"subscribers.account\":\"https://api.getdrip.com/v2/accounts/{subscribers.account}\"},\"subscribers\":[{\"id\":\"randomid\",\"href\":\"https://api.getdrip.com/v2/1234/subscribers/randomid\",\"status\":\"active\",\"email\":\"jdoe@example.com\",\"time_zone\":null,\"utc_offset\":0,\"visitor_uuid\":null,\"custom_fields\":{\"first_name\":\"John\"},\"tags\":[\"customer\"],\"created_at\":\"2018-06-04T21:29:49Z\",\"ip_address\":null,\"user_agent\":null,\"lifetime_value\":null,\"original_referrer\":null,\"landing_url\":null,\"prospect\":null,\"base_lead_score\":null,\"eu_consent\":\"unknown\",\"lead_score\":null,\"user_id\":\"123\",\"links\":{\"account\":\"1234\"}}]}")
 
       response = @client.subscriber('jdoe@example.com')

--- a/test/drip/request_test.rb
+++ b/test/drip/request_test.rb
@@ -1,0 +1,58 @@
+require File.dirname(__FILE__) + '/../test_helper.rb'
+require "drip/request"
+
+class Drip::RequestTest < Drip::TestCase
+  context "basic data" do
+    should "pass through data" do
+      request = Drip::Request.new(:get, "https://www.example.com/blah", { hello: "world" }, "application/vnd.visio")
+      assert_equal :get, request.http_verb
+      assert_equal "https://www.example.com/blah", request.url
+      assert_equal({ hello: "world" }, request.options)
+      assert_equal "application/vnd.visio", request.content_type
+    end
+  end
+
+  context "#verb_klass" do
+    context "when a supported verb" do
+      setup do
+        @subject = Drip::Request.new(:get, "https://www.example.com/blah", { hello: "world" }, "application/vnd.visio")
+      end
+
+      should "return a useful http class" do
+        assert_equal Net::HTTP::Get, @subject.verb_klass
+      end
+    end
+
+    context "when an unsupported verb" do
+      setup do
+        @subject = Drip::Request.new(:garbage, "https://www.example.com/blah", { hello: "world" }, "application/vnd.visio")
+      end
+
+      should "return nil" do
+        assert_nil @subject.verb_klass
+      end
+    end
+  end
+
+  context "#body" do
+    context "when HTTP GET" do
+      setup do
+        @subject = Drip::Request.new(:get, "https://www.example.com/blah", { hello: "world" }, "application/vnd.visio")
+      end
+
+      should "return nil" do
+        assert_nil @subject.body
+      end
+    end
+
+    context "when HTTP POST" do
+      setup do
+        @subject = Drip::Request.new(:post, "https://www.example.com/blah", { hello: "world" }, "application/vnd.visio")
+      end
+
+      should "return JSON" do
+        assert_equal '{"hello":"world"}', @subject.body
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changes:
- Restore deprecated get/post/put/delete methods auto-prepending `v2/` to URL.
- Create `Request` object and refactor code to use it.
- Create `HTTPClient` object and refactor code to use it. Migrate relevant tests from `Client` to `HTTPClient`. This reduces the responsibilities of the main `Client` class dramatically.
- Move and make private `Drip::Client::REDIRECT_LIMIT` constant.