### PR TITLE
Deprecate Drip::Client#generate_resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `Drip::Client#url_prefix` parameter no longer includes `/vN` part of the URL in order to prepare for Shopper Activity API. This breaks backwards compatibility for this option, but there is no expected production usage of this parameter.
 - `Drip::Client#get`, `Drip::Client#post`, `Drip::Client#put`, and `Drip::Client#delete` methods no longer auto-prepend `/v2` if the given path starts with `v2/` or `v3/`. This behavior is deprecated and will produce a warning. If you are using one of these methods and get this warning, just add `v2/` to the beginning of the path when you call it.
+- `Drip::Client#generate_resource` is deprecated and will be removed in a future version.
 
 ### Removed
 - Drop support for Ruby 2.1.

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -50,7 +50,8 @@ module Drip
     end
 
     def generate_resource(key, *args)
-      { key => args }
+      warn "[DEPRECATED] Drip::Client#generate_resource is deprecated and will be removed in a future version"
+      private_generate_resource(key, *args)
     end
 
     def content_type
@@ -74,6 +75,11 @@ module Drip
     end
 
   private
+
+    def private_generate_resource(key, *args)
+      # No reason for this to be part of the public API, so making a duplicate method to make it private.
+      { key => args }
+    end
 
     def make_uri(path)
       if !path.start_with?("v2/") && !path.start_with?("v3/")

--- a/lib/drip/client/events.rb
+++ b/lib/drip/client/events.rb
@@ -14,7 +14,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#record_event
       def track_event(email, action, properties = {}, options = {})
         data = options.merge({ "email" => email, "action" => action, "properties" => properties })
-        post "v2/#{account_id}/events", generate_resource("events", data)
+        post "v2/#{account_id}/events", private_generate_resource("events", data)
       end
 
       # Public: Track a collection of events all at once.
@@ -28,7 +28,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#event_batches
       def track_events(events)
         url = "v2/#{account_id}/events/batches"
-        post url, generate_resource("batches", { "events" => events })
+        post url, private_generate_resource("batches", { "events" => events })
       end
 
       # Public: Fetch all custom event actions.

--- a/lib/drip/client/orders.rb
+++ b/lib/drip/client/orders.rb
@@ -11,7 +11,7 @@ module Drip
       # See https://developer.drip.com/#orders
       def create_or_update_order(email, options = {})
         data = options.merge(email: email)
-        post "v2/#{account_id}/orders", generate_resource("orders", data)
+        post "v2/#{account_id}/orders", private_generate_resource("orders", data)
       end
 
       # Public: Create or update a batch of orders.
@@ -21,7 +21,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-batch-of-orders
       def create_or_update_orders(orders)
-        post "v2/#{account_id}/orders/batches", generate_resource("batches", { "orders" => orders })
+        post "v2/#{account_id}/orders/batches", private_generate_resource("batches", { "orders" => orders })
       end
 
       # Public: Create or update a refund.
@@ -38,7 +38,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-refund
       def create_or_update_refund(options)
-        post "v2/#{account_id}/refunds", generate_resource("refunds", options)
+        post "v2/#{account_id}/refunds", private_generate_resource("refunds", options)
       end
     end
   end

--- a/lib/drip/client/subscribers.rb
+++ b/lib/drip/client/subscribers.rb
@@ -51,7 +51,7 @@ module Drip
         data[:email] = args[0] if args[0].is_a? String
         data.merge!(args.last) if args.last.is_a? Hash
         raise ArgumentError, 'email: or id: parameter required' if !data.key?(:email) && !data.key?(:id)
-        post "v2/#{account_id}/subscribers", generate_resource("subscribers", data)
+        post "v2/#{account_id}/subscribers", private_generate_resource("subscribers", data)
       end
 
       # Public: Create or update a collection of subscribers.
@@ -71,7 +71,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def create_or_update_subscribers(subscribers)
         url = "v2/#{account_id}/subscribers/batches"
-        post url, generate_resource("batches", { "subscribers" => subscribers })
+        post url, private_generate_resource("batches", { "subscribers" => subscribers })
       end
 
       # Public: Unsubscribe a collection of subscribers.
@@ -83,7 +83,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#subscriber_batches
       def unsubscribe_subscribers(subscribers)
         url = "v2/#{account_id}/unsubscribes/batches"
-        post url, generate_resource("batches", { "subscribers" => subscribers })
+        post url, private_generate_resource("batches", { "subscribers" => subscribers })
       end
 
       # Public: Unsubscribe a subscriber globally or from a specific campaign.
@@ -127,7 +127,7 @@ module Drip
       def subscribe(email, campaign_id, options = {})
         data = options.merge("email" => email)
         url = "v2/#{account_id}/campaigns/#{campaign_id}/subscribers"
-        post url, generate_resource("subscribers", data)
+        post url, private_generate_resource("subscribers", data)
       end
 
       # Public: Delete a subscriber.

--- a/lib/drip/client/tags.rb
+++ b/lib/drip/client/tags.rb
@@ -20,7 +20,7 @@ module Drip
       # See https://www.getdrip.com/docs/rest-api#apply_tag
       def apply_tag(email, tag)
         data = { "email" => email, "tag" => tag }
-        post "v2/#{account_id}/tags", generate_resource("tags", data)
+        post "v2/#{account_id}/tags", private_generate_resource("tags", data)
       end
 
       # Public: Remove a tag from a subscriber.

--- a/lib/drip/client/webhooks.rb
+++ b/lib/drip/client/webhooks.rb
@@ -36,7 +36,7 @@ module Drip
         include_received_email = include_received_email ? true : false
         url = "v2/#{account_id}/webhooks"
 
-        post url, generate_resource(
+        post url, private_generate_resource(
           "webhooks",
           {
             "post_url" => post_url,

--- a/lib/drip/client/workflow_triggers.rb
+++ b/lib/drip/client/workflow_triggers.rb
@@ -22,7 +22,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def create_workflow_trigger(id, options = {})
-        post "v2/#{account_id}/workflows/#{id}/triggers", generate_resource("triggers", options)
+        post "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
       end
 
       # Public: Update a workflow trigger.
@@ -37,7 +37,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def update_workflow_trigger(id, options = {})
-        put "v2/#{account_id}/workflows/#{id}/triggers", generate_resource("triggers", options)
+        put "v2/#{account_id}/workflows/#{id}/triggers", private_generate_resource("triggers", options)
       end
     end
   end

--- a/lib/drip/client/workflows.rb
+++ b/lib/drip/client/workflows.rb
@@ -63,7 +63,7 @@ module Drip
       # Returns a Drip::Response.
       # See https://www.getdrip.com/docs/rest-api#workflows
       def start_subscriber_workflow(id, options = {})
-        post "v2/#{account_id}/workflows/#{id}/subscribers", generate_resource("subscribers", options)
+        post "v2/#{account_id}/workflows/#{id}/subscribers", private_generate_resource("subscribers", options)
       end
 
       # Public: Remove someone from a workflow.

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -58,6 +58,7 @@ class Drip::ClientTest < Drip::TestCase
   end
 
   context "#generate_resource" do
+    # Deprecated
     setup do
       @key = "subscribers"
       @data = { "email" => "foo" }
@@ -65,7 +66,9 @@ class Drip::ClientTest < Drip::TestCase
     end
 
     should "return a JSON API payload" do
-      assert_equal({ @key => [@data] }, @client.generate_resource(@key, @data))
+      assert_output(nil, /^\[DEPRECATED\] Drip\:\:Client\#generate_resource is deprecated/) do
+        assert_equal({ @key => [@data] }, @client.generate_resource(@key, @data))
+      end
     end
   end
 


### PR DESCRIPTION
This method is effectively an implementation detail. There is no reason for it to be public.

Extracted from the work on https://github.com/DripEmail/drip-ruby/pull/60