### PR TITLE
Extract content type to constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Drip::Client#url_prefix` parameter no longer includes `/vN` part of the URL in order to prepare for Shopper Activity API. This breaks backwards compatibility for this option, but there is no expected production usage of this parameter.
 - `Drip::Client#get`, `Drip::Client#post`, `Drip::Client#put`, and `Drip::Client#delete` methods no longer auto-prepend `/v2` if the given path starts with `v2/` or `v3/`. This behavior is deprecated and will produce a warning. If you are using one of these methods and get this warning, just add `v2/` to the beginning of the path when you call it.
 - `Drip::Client#generate_resource` is deprecated and will be removed in a future version.
+- `Drip::Client#content_type` is deprecated and will be removed in a future version. It is no longer used internally, effective immediately.
 
 ### Removed
 - Drop support for Ruby 2.1.

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -19,7 +19,7 @@ require "uri"
 require "json"
 
 module Drip
-  class Client
+  class Client # rubocop:disable Metrics/ClassLength
     include Accounts
     include Broadcasts
     include Campaigns

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -39,6 +39,9 @@ module Drip
 
     attr_accessor :access_token, :api_key, :account_id, :url_prefix, :http_open_timeout, :http_timeout
 
+    JSON_API_CONTENT_TYPE = "application/vnd.api+json".freeze
+    private_constant :JSON_API_CONTENT_TYPE
+
     def initialize(options = {})
       @account_id = options[:account_id]
       @access_token = options[:access_token]
@@ -55,7 +58,8 @@ module Drip
     end
 
     def content_type
-      'application/vnd.api+json'
+      warn "[DEPRECATED] Drip::Client#content_type is deprecated and will be removed in a future version"
+      JSON_API_CONTENT_TYPE
     end
 
     def get(url, options = {})
@@ -105,7 +109,7 @@ module Drip
           end
 
           request['User-Agent'] = "Drip Ruby v#{Drip::VERSION}"
-          request['Content-Type'] = content_type
+          request['Content-Type'] = JSON_API_CONTENT_TYPE
           request['Accept'] = "*/*"
 
           if access_token


### PR DESCRIPTION
And deprecate the unused method.

Extracted from work on https://github.com/DripEmail/drip-ruby/pull/60