### PR TITLE
Extract configuration object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Drip::Client#get`, `Drip::Client#post`, `Drip::Client#put`, and `Drip::Client#delete` methods no longer auto-prepend `/v2` if the given path starts with `v2/` or `v3/`. This behavior is deprecated and will produce a warning. If you are using one of these methods and get this warning, just add `v2/` to the beginning of the path when you call it.
 - `Drip::Client#generate_resource` is deprecated and will be removed in a future version.
 - `Drip::Client#content_type` is deprecated and will be removed in a future version. It is no longer used internally, effective immediately.
+- When using the block form of parameter initialization, a configuration object is provided instead of the client itself.
+- Calling configuration setters on `Drip::Client` is deprecated.
 
 ### Removed
 - Drop support for Ruby 2.1.

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -4,6 +4,7 @@ require "drip/client/accounts"
 require "drip/client/broadcasts"
 require "drip/client/campaigns"
 require "drip/client/campaign_subscriptions"
+require "drip/client/configuration"
 require "drip/client/conversions"
 require "drip/client/custom_fields"
 require "drip/client/events"
@@ -37,19 +38,24 @@ module Drip
 
     REDIRECT_LIMIT = 10
 
-    attr_accessor :access_token, :api_key, :account_id, :url_prefix, :http_open_timeout, :http_timeout
+    Drip::Client::Configuration::CONFIGURATION_FIELDS.each do |config_key|
+      define_method(config_key) do
+        @config.public_send(config_key)
+      end
+
+      setter_name = "#{config_key}=".to_sym
+      define_method(setter_name) do |val|
+        warn "[DEPRECATED] Setting configuration on Drip::Client after initialization will be removed in a future version"
+        @config.public_send(setter_name, val)
+      end
+    end
 
     JSON_API_CONTENT_TYPE = "application/vnd.api+json".freeze
     private_constant :JSON_API_CONTENT_TYPE
 
     def initialize(options = {})
-      @account_id = options[:account_id]
-      @access_token = options[:access_token]
-      @api_key = options[:api_key]
-      @url_prefix = options[:url_prefix] || "https://api.getdrip.com/"
-      @http_open_timeout = options[:http_open_timeout]
-      @http_timeout = options[:http_timeout]
-      yield(self) if block_given?
+      @config = Drip::Client::Configuration.new(options)
+      yield(@config) if block_given?
     end
 
     def generate_resource(key, *args)
@@ -90,7 +96,7 @@ module Drip
         warn "[DEPRECATED] Automatically prepended path with 'v2/'"
         path = "v2/#{path}"
       end
-      URI(url_prefix) + URI(path)
+      URI(@config.url_prefix) + URI(path)
     end
 
     def make_request(verb_klass, uri, options, step = 0)
@@ -113,9 +119,9 @@ module Drip
           request['Accept'] = "*/*"
 
           if access_token
-            request['Authorization'] = "Bearer #{access_token}"
+            request['Authorization'] = "Bearer #{@config.access_token}"
           else
-            request.basic_auth api_key, ""
+            request.basic_auth @config.api_key, ""
           end
 
           response = http.request request
@@ -138,12 +144,12 @@ module Drip
     def connection_options(uri_scheme)
       options = { use_ssl: uri_scheme == "https" }
 
-      if @http_open_timeout
-        options[:open_timeout] = @http_open_timeout
-        options[:ssl_timeout] = @http_open_timeout
+      if @config.http_open_timeout
+        options[:open_timeout] = @config.http_open_timeout
+        options[:ssl_timeout] = @config.http_open_timeout
       end
 
-      options[:read_timeout] = @http_timeout if @http_timeout
+      options[:read_timeout] = @config.http_timeout if @config.http_timeout
 
       options
     end

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -118,7 +118,7 @@ module Drip
           request['Content-Type'] = JSON_API_CONTENT_TYPE
           request['Accept'] = "*/*"
 
-          if access_token
+          if @config.access_token
             request['Authorization'] = "Bearer #{@config.access_token}"
           else
             request.basic_auth @config.api_key, ""

--- a/lib/drip/client/configuration.rb
+++ b/lib/drip/client/configuration.rb
@@ -1,0 +1,21 @@
+module Drip
+  class Client
+    class Configuration
+      DEFAULT_URL_PREFIX = "https://api.getdrip.com/".freeze
+      private_constant :DEFAULT_URL_PREFIX
+
+      CONFIGURATION_FIELDS = %i[access_token api_key account_id url_prefix http_open_timeout http_timeout].freeze
+
+      attr_accessor(*CONFIGURATION_FIELDS)
+
+      def initialize(access_token: nil, api_key: nil, account_id: nil, url_prefix: DEFAULT_URL_PREFIX, http_open_timeout: nil, http_timeout: nil) # rubocop:disable Metrics/ParameterLists
+        @access_token = access_token
+        @api_key = api_key
+        @account_id = account_id
+        @url_prefix = url_prefix
+        @http_open_timeout = http_open_timeout
+        @http_timeout = http_timeout
+      end
+    end
+  end
+end

--- a/lib/drip/client/configuration.rb
+++ b/lib/drip/client/configuration.rb
@@ -8,13 +8,17 @@ module Drip
 
       attr_accessor(*CONFIGURATION_FIELDS)
 
-      def initialize(access_token: nil, api_key: nil, account_id: nil, url_prefix: DEFAULT_URL_PREFIX, http_open_timeout: nil, http_timeout: nil) # rubocop:disable Metrics/ParameterLists
-        @access_token = access_token
-        @api_key = api_key
-        @account_id = account_id
-        @url_prefix = url_prefix
-        @http_open_timeout = http_open_timeout
-        @http_timeout = http_timeout
+      def initialize(**options)
+        remainder = options.keys - CONFIGURATION_FIELDS
+        raise ArgumentError, "unknown keyword#{'s' if remainder.size > 1}: #{remainder.join(', ')}" unless remainder.empty?
+
+        options.each do |k, v|
+          public_send("#{k}=".to_sym, v)
+        end
+      end
+
+      def url_prefix
+        @url_prefix || DEFAULT_URL_PREFIX
       end
     end
   end

--- a/lib/drip/client/configuration.rb
+++ b/lib/drip/client/configuration.rb
@@ -12,6 +12,9 @@ module Drip
         remainder = options.keys - CONFIGURATION_FIELDS
         raise ArgumentError, "unknown keyword#{'s' if remainder.size > 1}: #{remainder.join(', ')}" unless remainder.empty?
 
+        # Initialize this variable to suppress Ruby warning.
+        @url_prefix = nil
+
         options.each do |k, v|
           public_send("#{k}=".to_sym, v)
         end

--- a/lib/drip/client/configuration.rb
+++ b/lib/drip/client/configuration.rb
@@ -16,7 +16,7 @@ module Drip
         @url_prefix = nil
 
         options.each do |k, v|
-          public_send("#{k}=".to_sym, v)
+          public_send("#{k}=", v)
         end
       end
 

--- a/test/drip/client/configuration_test.rb
+++ b/test/drip/client/configuration_test.rb
@@ -2,6 +2,41 @@ require File.dirname(__FILE__) + '/../../test_helper.rb'
 require "drip/client/configuration"
 
 class Drip::Client::ConfigurationTest < Drip::TestCase
+  context "#initializer" do
+    context "with reasonable parameters" do
+      should "accept parameters" do
+        config = Drip::Client::Configuration.new(access_token: "123")
+        assert_equal "123", config.access_token
+      end
+    end
+
+    context "with one additional parameter" do
+      should "raise singular error" do
+        err = assert_raises(ArgumentError) { Drip::Client::Configuration.new(blahdeblah: "123") }
+        assert_equal "unknown keyword: blahdeblah", err.message
+      end
+
+      should "match core ruby behavior" do
+        def test_method(hello: "test"); end
+        err = assert_raises(ArgumentError) { test_method(blahdeblah: "123") }
+        assert_equal "unknown keyword: blahdeblah", err.message
+      end
+    end
+
+    context "with multiple additional parameters" do
+      should "raise plural error" do
+        err = assert_raises(ArgumentError) { Drip::Client::Configuration.new(blahdeblah: "123", blahdeblah1: "123") }
+        assert_equal "unknown keywords: blahdeblah, blahdeblah1", err.message
+      end
+
+      should "match core ruby behavior" do
+        def test_method(hello: "test"); end
+        err = assert_raises(ArgumentError) { test_method(blahdeblah: "123", blahdeblah1: "123") }
+        assert_equal "unknown keywords: blahdeblah, blahdeblah1", err.message
+      end
+    end
+  end
+
   context "#url_prefix" do
     should "have default url prefix" do
       config = Drip::Client::Configuration.new
@@ -12,39 +47,75 @@ class Drip::Client::ConfigurationTest < Drip::TestCase
       config = Drip::Client::Configuration.new(url_prefix: "https://www.example.com/")
       assert_equal "https://www.example.com/", config.url_prefix
     end
+
+    should "allow setter" do
+      config = Drip::Client::Configuration.new
+      config.url_prefix = "https://www.example.com/"
+      assert_equal "https://www.example.com/", config.url_prefix
+    end
   end
 
   context "#access_token" do
-    should "round-trip data" do
+    should "accept passed parameter" do
       config = Drip::Client::Configuration.new(access_token: "blah")
+      assert_equal "blah", config.access_token
+    end
+
+    should "allow setter" do
+      config = Drip::Client::Configuration.new
+      config.access_token = "blah"
       assert_equal "blah", config.access_token
     end
   end
 
   context "#api_key" do
-    should "round-trip data" do
+    should "accept passed parameter" do
       config = Drip::Client::Configuration.new(api_key: "blah")
+      assert_equal "blah", config.api_key
+    end
+
+    should "allow setter" do
+      config = Drip::Client::Configuration.new
+      config.api_key = "blah"
       assert_equal "blah", config.api_key
     end
   end
 
   context "#account_id" do
-    should "round-trip data" do
+    should "accept passed parameter" do
       config = Drip::Client::Configuration.new(account_id: "1234567")
+      assert_equal "1234567", config.account_id
+    end
+
+    should "allow setter" do
+      config = Drip::Client::Configuration.new
+      config.account_id = "1234567"
       assert_equal "1234567", config.account_id
     end
   end
 
   context "#http_open_timeout" do
-    should "round-trip data" do
+    should "accept passed parameter" do
       config = Drip::Client::Configuration.new(http_open_timeout: 12)
+      assert_equal 12, config.http_open_timeout
+    end
+
+    should "allow setter" do
+      config = Drip::Client::Configuration.new
+      config.http_open_timeout = 12
       assert_equal 12, config.http_open_timeout
     end
   end
 
   context "#http_timeout" do
-    should "round-trip data" do
+    should "accept passed parameter" do
       config = Drip::Client::Configuration.new(http_timeout: 42)
+      assert_equal 42, config.http_timeout
+    end
+
+    should "allow setter" do
+      config = Drip::Client::Configuration.new
+      config.http_timeout = 42
       assert_equal 42, config.http_timeout
     end
   end

--- a/test/drip/client/configuration_test.rb
+++ b/test/drip/client/configuration_test.rb
@@ -1,0 +1,51 @@
+require File.dirname(__FILE__) + '/../../test_helper.rb'
+require "drip/client/configuration"
+
+class Drip::Client::ConfigurationTest < Drip::TestCase
+  context "#url_prefix" do
+    should "have default url prefix" do
+      config = Drip::Client::Configuration.new
+      assert_equal "https://api.getdrip.com/", config.url_prefix
+    end
+
+    should "accept passed parameter" do
+      config = Drip::Client::Configuration.new(url_prefix: "https://www.example.com/")
+      assert_equal "https://www.example.com/", config.url_prefix
+    end
+  end
+
+  context "#access_token" do
+    should "round-trip data" do
+      config = Drip::Client::Configuration.new(access_token: "blah")
+      assert_equal "blah", config.access_token
+    end
+  end
+
+  context "#api_key" do
+    should "round-trip data" do
+      config = Drip::Client::Configuration.new(api_key: "blah")
+      assert_equal "blah", config.api_key
+    end
+  end
+
+  context "#account_id" do
+    should "round-trip data" do
+      config = Drip::Client::Configuration.new(account_id: "1234567")
+      assert_equal "1234567", config.account_id
+    end
+  end
+
+  context "#http_open_timeout" do
+    should "round-trip data" do
+      config = Drip::Client::Configuration.new(http_open_timeout: 12)
+      assert_equal 12, config.http_open_timeout
+    end
+  end
+
+  context "#http_timeout" do
+    should "round-trip data" do
+      config = Drip::Client::Configuration.new(http_timeout: 42)
+      assert_equal 42, config.http_timeout
+    end
+  end
+end

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -19,11 +19,6 @@ class Drip::ClientTest < Drip::TestCase
       assert_equal "aaaa", client.url_prefix
     end
 
-    should "have default url prefix" do
-      client = Drip::Client.new
-      assert_equal "https://api.getdrip.com/", client.url_prefix
-    end
-
     should "accept access token" do
       client = Drip::Client.new do |config|
         config.access_token = "aaaa"


### PR DESCRIPTION
Encapsulates incoming data and makes it easier to pass this to other classes (coming in another PR).

Extracted from work on https://github.com/DripEmail/drip-ruby/pull/60