### PR TITLE
Add shopper activity batch api

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,7 @@ Layout/MultilineMethodCallIndentation:
 Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'

--- a/lib/drip/client/shopper_activity.rb
+++ b/lib/drip/client/shopper_activity.rb
@@ -43,7 +43,7 @@ module Drip
       #                       Refer to the Drip API docs for the required schema.
       #
       # Returns a Drip::Response.
-      # See https://developer.drip.com/#order-activity
+      # See https://developer.drip.com/#create-or-update-a-batch-of-orders
       def create_order_activity_events(records = [])
         records.each_with_index do |rec, i|
           raise ArgumentError, "email: or person_id: parameter required in record #{i}" if !rec.key?(:email) && !rec.key?(:person_id)

--- a/lib/drip/client/shopper_activity.rb
+++ b/lib/drip/client/shopper_activity.rb
@@ -37,6 +37,27 @@ module Drip
         make_json_request :post, "v3/#{account_id}/shopper_activity/order", data
       end
 
+      # Public: Create a batch of order activity events.
+      #
+      # options    - Required. An array of hashes containing additional order options.
+      #                       Refer to the Drip API docs for the required schema.
+      #
+      # Returns a Drip::Response.
+      # See https://developer.drip.com/#order-activity
+      def create_order_activity_events(records = [])
+        records.each_with_index do |rec, i|
+          raise ArgumentError, "email: or person_id: parameter required in record #{i}" if !rec.key?(:email) && !rec.key?(:person_id)
+
+          %i[provider action order_id].each do |key|
+            raise ArgumentError, "#{key}: parameter required in record #{i}" unless rec.key?(key)
+          end
+
+          rec[:occurred_at] = Time.now.iso8601 unless rec.key?(:occurred_at)
+        end
+
+        make_json_request :post, "v3/#{account_id}/shopper_activity/order/batch", records
+      end
+
       # Public: Create a product activity event.
       #
       # options    - Required. A Hash of additional product options. Refer to the

--- a/lib/drip/client/shopper_activity.rb
+++ b/lib/drip/client/shopper_activity.rb
@@ -39,7 +39,7 @@ module Drip
 
       # Public: Create a batch of order activity events.
       #
-      # options    - Required. An array of hashes containing additional order options.
+      # records    - Required. An array of hashes containing orders attributes.
       #                       Refer to the Drip API docs for the required schema.
       #
       # Returns a Drip::Response.

--- a/lib/drip/client/shopper_activity.rb
+++ b/lib/drip/client/shopper_activity.rb
@@ -45,14 +45,14 @@ module Drip
       # Returns a Drip::Response.
       # See https://developer.drip.com/#create-or-update-a-batch-of-orders
       def create_order_activity_events(records = [])
-        records.each_with_index do |rec, i|
-          raise ArgumentError, "email: or person_id: parameter required in record #{i}" if !rec.key?(:email) && !rec.key?(:person_id)
+        records.each_with_index do |record, i|
+          raise ArgumentError, "email: or person_id: parameter required in record #{i}" if !record.key?(:email) && !record.key?(:person_id)
 
           %i[provider action order_id].each do |key|
-            raise ArgumentError, "#{key}: parameter required in record #{i}" unless rec.key?(key)
+            raise ArgumentError, "#{key}: parameter required in record #{i}" unless record.key?(key)
           end
 
-          rec[:occurred_at] = Time.now.iso8601 unless rec.key?(:occurred_at)
+          record[:occurred_at] = Time.now.iso8601 unless record.key?(:occurred_at)
         end
 
         make_json_request :post, "v3/#{account_id}/shopper_activity/order/batch", records

--- a/test/drip/client/shopper_activity_test.rb
+++ b/test/drip/client/shopper_activity_test.rb
@@ -80,6 +80,60 @@ class Drip::Client::ShopperActivityTest < Drip::TestCase
     end
   end
 
+  context "#create_order_activity_events" do
+    setup do
+      @records = [
+        {
+          email: "drippy@example.com",
+          action: "created",
+          provider: "shopify",
+          order_id: "abcdef",
+          amount: 4900,
+          tax: 100,
+          fees: 0,
+          discount: 0,
+          currency_code: "USD",
+          properties: {
+            "size" => "medium",
+            "color" => "red"
+          }
+        },
+        {
+          email: "drippy1@example.com",
+          action: "created",
+          provider: "shopify",
+          order_id: "fdsgs",
+          amount: 4900,
+          tax: 100,
+          fees: 0,
+          discount: 0,
+          currency_code: "USD",
+          properties: {
+            "size" => "medium",
+            "color" => "red"
+          }
+        }
+      ]
+      @response_status = 202
+      @response_body = "{}"
+
+      stub_request(:post, "https://api.getdrip.com/v3/12345/shopper_activity/order/batch").
+        with(headers: { "Content-Type" => "application/json" }).
+        to_return(status: @response_status, body: @response_body, headers: {})
+    end
+
+    should "send the right request" do
+      expected = Drip::Response.new(@response_status, JSON.parse(@response_body))
+      assert_equal expected, @client.create_order_activity_events(@records)
+    end
+
+    should "return error when missing fields" do
+      @records[1].delete(:order_id)
+      err = assert_raises(ArgumentError) { @client.create_order_activity_events(@records) }
+      assert_equal "order_id: parameter required in record 1", err.message
+    end
+  end
+
   context "#create_product_activity_event" do
     setup do
       @email = "drippy@drip.com"


### PR DESCRIPTION
Missed this in the first round. Follows https://github.com/DripEmail/drip-ruby/pull/59

Part of https://github.com/DripEmail/drip-ruby/issues/55

Implements https://developer.drip.com/#create-or-update-a-batch-of-orders