### PR TITLE
Implement users API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-[master]: https://github.com/DripEmail/drip-ruby/compare/v3.3.1...HEAD
+[master]: https://github.com/DripEmail/drip-ruby/compare/v3.3.2...HEAD
 
 - Your contribution here!
+
+## [3.3.2] - 2020-04-21
+
+[3.3.2]: https://github.com/DripEmail/drip-ruby/compare/v3.3.1...v3.3.2
+
+### Added
+- Support for the user endpoint in the REST API
+
+### Changed
+- `Drip::Client#create_cart_activity_event` can be used with visitor UUID
 
 ## [3.3.1] - 2019-05-28
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ as methods on the client object. The following methods are currently available:
 | Apply a tag                | `#apply_tag(email, tag)`                             |
 | Remove a tag               | `#remove_tag(email, tag)`                            |
 
+
+#### Users
+| Actions                    | Methods                                              |
+| :------------------------- | :--------------------------------------------------- |
+| Fetch user                 | `#user`                                              |
+
 #### Webhooks
 
 | Actions                    | Methods                                              |

--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -17,6 +17,7 @@ require "drip/client/orders"
 require "drip/client/shopper_activity"
 require "drip/client/subscribers"
 require "drip/client/tags"
+require "drip/client/users"
 require "drip/client/webhooks"
 require "drip/client/workflows"
 require "drip/client/workflow_triggers"
@@ -38,6 +39,7 @@ module Drip
     include ShopperActivity
     include Subscribers
     include Tags
+    include Users
     include Webhooks
     include Workflows
     include WorkflowTriggers

--- a/lib/drip/client/users.rb
+++ b/lib/drip/client/users.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "cgi"
+
+module Drip
+  class Client
+    module Users
+      # Public: Fetch the authenticated user
+      #
+      # Returns a Drip::Response.
+      # See https://developer.drip.com/#users
+      def user
+        make_json_api_request :get, "v2/user"
+      end
+    end
+  end
+end
+

--- a/lib/drip/client/users.rb
+++ b/lib/drip/client/users.rb
@@ -15,4 +15,3 @@ module Drip
     end
   end
 end
-

--- a/test/drip/client/users_test.rb
+++ b/test/drip/client/users_test.rb
@@ -11,7 +11,7 @@ class Drip::Client::UsersTest < Drip::TestCase
     setup do
       @response_status = 200
       @response_body = "{}"
-      
+
       stub_request(:get, "https://api.getdrip.com/v2/user").
         to_return(status: @response_status, body: @response_body, headers: {})
     end

--- a/test/drip/client/users_test.rb
+++ b/test/drip/client/users_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require File.dirname(__FILE__) + '/../../test_helper.rb'
+
+class Drip::Client::UsersTest < Drip::TestCase
+  def setup
+    @client = Drip::Client.new { |c| c.account_id = "12345" }
+  end
+
+  context "#user" do
+    setup do
+      @response_status = 200
+      @response_body = "{}"
+      
+      stub_request(:get, "https://api.getdrip.com/v2/user").
+        to_return(status: @response_status, body: @response_body, headers: {})
+    end
+
+    should "send the right request" do
+      expected = Drip::Response.new(@response_status, JSON.parse(@response_body))
+      assert_equal expected, @client.user
+    end
+  end
+end


### PR DESCRIPTION
Fixes: https://github.com/DripEmail/drip-ruby/issues/69

Implements API endpoint to fetch the authenticated user: [https://developer.drip.com/?ruby#users](https://developer.drip.com/?ruby#users)