### PR TITLE
ECI-1261 allow use of bigcommerce_subscriber_id as lookup key to create or update subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [master]: https://github.com/DripEmail/drip-ruby/compare/v3.4.1...HEAD
 
+### Changed
+- `Drip::Client#create_or_update_subscriber` can be used with a BigCommerce Subscriber ID as the required key
+
 - Your contribution here!
 
 ## [3.4.1] - 2020-04-21

--- a/test/drip/client/subscribers_test.rb
+++ b/test/drip/client/subscribers_test.rb
@@ -84,6 +84,12 @@ class Drip::Client::SubscribersTest < Drip::TestCase
       assert_equal expected, @client.create_or_update_subscriber(id: 123456)
       assert_requested :post, "https://api.getdrip.com/v2/12345/subscribers", body: '{"subscribers":[{"id":123456}]}', times: 1
     end
+
+    should "allow request with bigcommerce_subscriber_id keyword argument" do
+      expected = Drip::Response.new(@response_status, JSON.parse(@response_body))
+      assert_equal expected, @client.create_or_update_subscriber(external_ids: { "bigcommerce_subscriber_id" => "2" })
+      assert_requested :post, "https://api.getdrip.com/v2/12345/subscribers", body: '{"subscribers":[{"external_ids":{"bigcommerce_subscriber_id":"2"}}]}', times: 1
+    end
   end
 
   context "#create_or_update_subscribers" do


### PR DESCRIPTION
Addresses: [ECI-1261](https://dripcom.atlassian.net/browse/ECI-1261)

Followup to: https://github.com/DripEmail/drip/pull/21175 AND https://github.com/DripEmail/woo/pull/465

Honeybadger: https://app.honeybadger.io/projects/67590/faults/79484576

## Background

For BigCommerce subscriber deleted events, we need to unsubscribe the subscriber in our system. BigCommerce only supplies their id for the deleted subscriber in the webhook payload, not the email. Previously changes allow the monolith subscriber endpoint to handle the lookup by bigcommerce_subscriber_id, but to make this call in the integration service we need to allow it as one of the possible required fields in the client as well.

## Modification

Check if an `external_ids` value for `bigcommerce_subscriber_id` is present in the create_or_update_subscriber arguments. If it is, then we no longer want to raise an argument error.

## How to verify/test

Right now BigCommerce is feature flagged, and once this is incorporated I plan to do another end to end test through our system.
