### PR TITLE
Added support for skip_analytics config option.

### DIFF
--- a/lib/drip/client/configuration.rb
+++ b/lib/drip/client/configuration.rb
@@ -6,7 +6,10 @@ module Drip
       DEFAULT_URL_PREFIX = "https://api.getdrip.com/"
       private_constant :DEFAULT_URL_PREFIX
 
-      CONFIGURATION_FIELDS = %i[access_token api_key account_id url_prefix http_open_timeout http_timeout].freeze
+      CONFIGURATION_FIELDS = %i[
+        access_token api_key account_id url_prefix http_open_timeout
+        http_timeout skip_analytics
+      ].freeze
 
       attr_accessor(*CONFIGURATION_FIELDS)
 

--- a/lib/drip/client/configuration.rb
+++ b/lib/drip/client/configuration.rb
@@ -7,8 +7,13 @@ module Drip
       private_constant :DEFAULT_URL_PREFIX
 
       CONFIGURATION_FIELDS = %i[
-        access_token api_key account_id url_prefix http_open_timeout
-        http_timeout skip_analytics
+        access_token
+        account_id
+        api_key
+        http_open_timeout
+        http_timeout
+        skip_analytics
+        url_prefix
       ].freeze
 
       attr_accessor(*CONFIGURATION_FIELDS)

--- a/lib/drip/client/http_client.rb
+++ b/lib/drip/client/http_client.rb
@@ -46,6 +46,7 @@ module Drip
           request.basic_auth @config.api_key, ""
         end
 
+        request['Skip-Analytics'] = true if @config.skip_analytics
         request
       end
 

--- a/test/drip/client/configuration_test.rb
+++ b/test/drip/client/configuration_test.rb
@@ -109,4 +109,17 @@ class Drip::Client::ConfigurationTest < Drip::TestCase
       assert_equal 42, config.http_timeout
     end
   end
+
+  context "#skip_analytics" do
+    should "accept passed parameter" do
+      config = Drip::Client::Configuration.new(skip_analytics: true)
+      assert_equal true, config.skip_analytics
+    end
+
+    should "allow setter" do
+      config = Drip::Client::Configuration.new
+      config.skip_analytics = true
+      assert_equal true, config.skip_analytics
+    end
+  end
 end

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -43,7 +43,8 @@ class Drip::ClientTest < Drip::TestCase
         api_key: "aaaa",
         access_token: "bbbb",
         http_open_timeout: 20,
-        http_timeout: 25
+        http_timeout: 25,
+        skip_analytics: true
       )
 
       assert_equal "1234567", client.account_id
@@ -51,6 +52,7 @@ class Drip::ClientTest < Drip::TestCase
       assert_equal "bbbb", client.access_token
       assert_equal 20, client.http_open_timeout
       assert_equal 25, client.http_timeout
+      assert_equal true, client.skip_analytics
     end
 
     should "accept options after initialization" do

--- a/test/drip/client_test.rb
+++ b/test/drip/client_test.rb
@@ -52,7 +52,7 @@ class Drip::ClientTest < Drip::TestCase
       assert_equal "bbbb", client.access_token
       assert_equal 20, client.http_open_timeout
       assert_equal 25, client.http_timeout
-      assert_equal true, client.skip_analytics
+      assert client.skip_analytics, "config should skip analytics"
     end
 
     should "accept options after initialization" do


### PR DESCRIPTION
## Background

Drip support recomended I try adding the "Skip-Analytics" header because our customers are getting the "Endpoint request timed out" error with our integration. This error is also mentioned in #54 which still throws an unproperly handled error. 

## Modification

Added configuration option `skip_analytics` that you can pass into the client initializer.

## Result

According to support and my testing it'll skip adding count related metadata.