### PR TITLE
WIP: Attempt to fix issue submitted via github

### DIFF
--- a/lib/drip/client/shopper_activity.rb
+++ b/lib/drip/client/shopper_activity.rb
@@ -18,7 +18,7 @@ module Drip
         end
 
         data[:occurred_at] = Time.now.iso8601 unless data.key?(:occurred_at)
-        make_json_request :post, "v3/#{account_id}/shopper_activity/cart", data
+        make_json_request :post, "v3/#{account_id}/shopper_activity/cart", data.to_json
       end
 
       # Public: Create an order activity event.
@@ -36,7 +36,7 @@ module Drip
         end
 
         data[:occurred_at] = Time.now.iso8601 unless data.key?(:occurred_at)
-        make_json_request :post, "v3/#{account_id}/shopper_activity/order", data
+        make_json_request :post, "v3/#{account_id}/shopper_activity/order", data.to_json
       end
 
       # Public: Create a batch of order activity events.
@@ -57,7 +57,7 @@ module Drip
           record[:occurred_at] = Time.now.iso8601 unless record.key?(:occurred_at)
         end
 
-        make_json_request :post, "v3/#{account_id}/shopper_activity/order/batch", { orders: records }
+        make_json_request :post, "v3/#{account_id}/shopper_activity/order/batch", { orders: records.to_json }
       end
 
       # Public: Create a product activity event.
@@ -73,7 +73,7 @@ module Drip
         end
 
         data[:occurred_at] = Time.now.iso8601 unless data.key?(:occurred_at)
-        make_json_request :post, "v3/#{account_id}/shopper_activity/product", data
+        make_json_request :post, "v3/#{account_id}/shopper_activity/product", data.to_json
       end
     end
   end

--- a/test/drip/client/shopper_activity_test.rb
+++ b/test/drip/client/shopper_activity_test.rb
@@ -35,7 +35,7 @@ class Drip::Client::ShopperActivityTest < Drip::TestCase
     end
 
     should "send the right request" do
-      expected = Drip::Response.new(@response_status, JSON.parse(@response_body))
+      expected = Drip::Response.new(@response_status, @response_body.to_json)
       assert_equal expected, @client.create_cart_activity_event(@options)
     end
 
@@ -84,7 +84,7 @@ class Drip::Client::ShopperActivityTest < Drip::TestCase
     end
 
     should "send the right request" do
-      expected = Drip::Response.new(@response_status, JSON.parse(@response_body))
+      expected = Drip::Response.new(@response_status, @response_body.to_json)
       assert_equal expected, @client.create_order_activity_event(@options)
     end
 
@@ -137,7 +137,7 @@ class Drip::Client::ShopperActivityTest < Drip::TestCase
     end
 
     should "send the right request" do
-      expected = Drip::Response.new(@response_status, JSON.parse(@response_body))
+      expected = Drip::Response.new(@response_status, @response_body.to_json)
       assert_equal expected, @client.create_order_activity_events(@records)
     end
 
@@ -177,7 +177,7 @@ class Drip::Client::ShopperActivityTest < Drip::TestCase
     end
 
     should "send the right request" do
-      expected = Drip::Response.new(@response_status, JSON.parse(@response_body))
+      expected = Drip::Response.new(@response_status, @response_body.to_json)
       assert_equal expected, @client.create_product_activity_event(@options)
     end
 


### PR DESCRIPTION
WIP

Addresses: https://github.com/DripEmail/drip-ruby/issues/80

## Background

Our API doesn't store data properly as a JSON object; rather, it's a Ruby hash

## Modification

Store objects as JSON

## Result

API should store objects in a usable way

## Additional Context

N/A

## How to verify/test

I'm not sure yet, as I've never worked with this repo before.  Please advise