### PR TITLE
Adds checkout type calls to Shopper Activity

### DIFF
--- a/lib/drip/client/shopper_activity.rb
+++ b/lib/drip/client/shopper_activity.rb
@@ -85,7 +85,7 @@ module Drip
       # See https://developer.drip.com/#checkout-activity
       def create_checkout_activity_event(data = {})
         %i[provider action checkout_id].each do |key|
-          raise ArgumentError, "#{key}: parameter required" if !data.key?(:email) && !data.key?(:person_id)
+          raise ArgumentError, "#{key}: parameter required" if !data.key?(key)
         end
 
         data[:occurred_at] = Time.now.iso8601 unless data.key?(:occurred_at)

--- a/lib/drip/client/shopper_activity.rb
+++ b/lib/drip/client/shopper_activity.rb
@@ -75,6 +75,22 @@ module Drip
         data[:occurred_at] = Time.now.iso8601 unless data.key?(:occurred_at)
         make_json_request :post, "v3/#{account_id}/shopper_activity/product", data
       end
+
+      # Public: Create a checkout activity event.
+      #
+      # options    - Required. A Hash of additional checkout options. Refer to the
+      #                       Drip API docs for the required schema.
+      #
+      # Returns a Drip::Response.
+      # See https://developer.drip.com/#checkout-activity
+      def create_checkout_activity_event(data = {})
+        %i[provider action checkout_id].each do |key|
+          raise ArgumentError, "#{key}: parameter required" if !data.key?(:email) && !data.key?(:person_id)
+        end
+
+        data[:occurred_at] = Time.now.iso8601 unless data.key?(:occurred_at)
+        make_json_request :post, "v3/#{account_id}/shopper_activity/checkout", data
+      end
     end
   end
 end

--- a/test/drip/client/shopper_activity_test.rb
+++ b/test/drip/client/shopper_activity_test.rb
@@ -186,4 +186,38 @@ class Drip::Client::ShopperActivityTest < Drip::TestCase
       assert_raises(ArgumentError) { @client.create_product_activity_event(@options) }
     end
   end
+
+  context "#create_checkout_activity_event" do
+    setup do
+      @email = "drippy@drip.com"
+      @options = {
+        email: @email,
+        provider: "shopify",
+        action: "created",
+        occurred_at: "2019-01-28T12:15:23Z",
+        checkout_id: "B01J4",
+        total_price: 11.16
+      }
+      @response_status = 202
+      @response_body = "{}"
+
+      stub_request(:post, "https://api.getdrip.com/v3/12345/shopper_activity/checkout").
+        with(headers: { "Content-Type" => "application/json" }).
+        to_return(status: @response_status, body: @response_body, headers: {})
+    end
+
+    should "send the right request" do
+      expected = Drip::Response.new(@response_status, JSON.parse(@response_body))
+      assert_equal expected, @client.create_checkout_activity_event(@options)
+    end
+
+    should "return error with missing fields" do
+      %i[provider action checkout_id].each do |key|
+        params = @options.dup
+        params.delete(key)
+
+        assert_raises(ArgumentError) { @client.create_checkout_activity_event(params) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Addresses: [ECI-1757](https://dripcom.atlassian.net/browse/ECI-1757)

Required to properly test [this PR on Shopper Activity](https://github.com/DripEmail/shopper-activity/pull/560)

## Background

So, ECI-1638 is about creating a `checkout` type in the SA lambdas. They are created now, and even added to the API Gateway (on staging, for the time being). However, in order to test that I need a real event to see how they come and go. So, I need to modify the WIS so it sends `checkout` events to SA instead of the Monolith.

I added that [in a WIS PR](https://github.com/DripEmail/woo/pull/896) BUT it's currently failing because `create_checkout_activity_event` is not defined in the `Drip::Client`.

So here we are.

## Modification

Adds a `create_checkout_activity_event` to the Drip client.

## Result

This complicated rabbit hole of requirements is fulfilled and we can proceed one step further.

[ECI-1757]: https://dripcom.atlassian.net/browse/ECI-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ