### PR TITLE
Bumps gem version to include new changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-[master]: https://github.com/DripEmail/drip-ruby/compare/v3.4.2...HEAD
+[master]: https://github.com/DripEmail/drip-ruby/compare/v3.4.3...HEAD
 
 - Your contribution here!
+
+## [3.4.3] - 2023-02-15
+
+[3.4.3]: https://github.com/DripEmail/drip-ruby/compare/v3.4.2...v3.4.3
+
+### Added
+- `Drip::Client::ShopperActivity#create_checkout_activity_event` can create `checkout` activity events now
 
 ## [3.4.2] - 2021-04-25
 

--- a/lib/drip/version.rb
+++ b/lib/drip/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Drip
-  VERSION = "3.4.2"
+  VERSION = "3.4.3"
 end


### PR DESCRIPTION
Addresses: [ECI-1757](https://dripcom.atlassian.net/browse/ECI-1757)

## Background

Previous PR (#82) didn't bump the gem's version, so although the change was made (and merged, as it got enough reviews), but after being deployed to Woo's staging environment, the changes were not reflected (because it was the "same" version). This changes enforces that update.

## Modification

New method is added and, hopefully, available everywhere (when they're pointing towards the newest ref).

## Result

Gem's version is updated from `3.4.2` to `3.4.3`.

[ECI-1757]: https://dripcom.atlassian.net/browse/ECI-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ